### PR TITLE
feat: implement Phase 2 read tools (#8-#25)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -24,38 +24,38 @@ GitHub Project: [Meta Ads MCP](https://github.com/users/tomleelong/projects/2)
 ## Phase 2: Read Tools
 
 ### Accounts
-- [ ] #8 `get_ad_accounts` — list accessible ad accounts
-- [ ] #9 `get_account_info` — detailed account info
+- [x] #8 `get_ad_accounts` — list accessible ad accounts
+- [x] #9 `get_account_info` — detailed account info
 
 ### Campaigns
-- [ ] #10 `list_campaigns` — list with status filtering
-- [ ] #11 `get_campaign` — detailed campaign info
+- [x] #10 `list_campaigns` — list with status filtering
+- [x] #11 `get_campaign` — detailed campaign info
 
 ### Ad Sets
-- [ ] #12 `list_ad_sets` — list with campaign filter
-- [ ] #13 `get_ad_set` — detailed ad set info with targeting
+- [x] #12 `list_ad_sets` — list with campaign filter
+- [x] #13 `get_ad_set` — detailed ad set info with targeting
 
 ### Ads
-- [ ] #14 `list_ads` — list with ad set/campaign filter
-- [ ] #15 `get_ad` — detailed ad info with creative reference
+- [x] #14 `list_ads` — list with ad set/campaign filter
+- [x] #15 `get_ad` — detailed ad info with creative reference
 
 ### Insights
-- [ ] #16 `get_insights` — flexible date/breakdowns/level query
-- [ ] #17 `get_campaign_insights` — campaign performance with period comparison
-- [ ] #18 `get_account_insights` — account-level performance metrics
-- [ ] #19 `compare_performance` — compare entities side-by-side
-- [ ] #20 `get_breakdown_report` — age/gender/placement/device breakdowns
+- [x] #16 `get_insights` — flexible date/breakdowns/level query
+- [x] #17 `get_campaign_insights` — campaign performance with period comparison
+- [x] #18 `get_account_insights` — account-level performance metrics
+- [x] #19 `compare_performance` — compare entities side-by-side
+- [x] #20 `get_breakdown_report` — age/gender/placement/device breakdowns
 
 ### Creatives
-- [ ] #21 `list_creatives` — list ad creatives
-- [ ] #22 `get_creative` — creative details with thumbnail and body
+- [x] #21 `list_creatives` — list ad creatives
+- [x] #22 `get_creative` — creative details with thumbnail and body
 
 ### Audiences
-- [ ] #23 `list_audiences` — custom and lookalike audiences
-- [ ] #24 `get_audience` — audience details, size, status
+- [x] #23 `list_audiences` — custom and lookalike audiences
+- [x] #24 `get_audience` — audience details, size, status
 
 ### Testing
-- [ ] #25 Unit tests for all read tools with mocked fixtures
+- [x] #25 Unit tests for all read tools with mocked fixtures
 
 ## Phase 3: Write Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,7 @@ disable_error_code = ["import-untyped"]
 [[tool.mypy.overrides]]
 module = ["decouple", "facebook_business.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["meta_ads_mcp.tools.*"]
+disable_error_code = ["type-arg"]

--- a/src/meta_ads_mcp/formatting.py
+++ b/src/meta_ads_mcp/formatting.py
@@ -392,6 +392,125 @@ def format_audience_list(audiences: list[CustomAudienceModel]) -> str:
     return "\n".join(lines)
 
 
+def format_insights_comparison(
+    current: InsightRow | None,
+    previous: InsightRow | None,
+    current_label: str,
+    previous_label: str,
+) -> str:
+    """Format a period-over-period comparison of insight metrics.
+
+    Shows metrics as rows with columns for Current, Previous, Change, and Change %.
+
+    Args:
+        current: Current period insight row, or None if no data.
+        previous: Previous period insight row, or None if no data.
+        current_label: Label for the current period (e.g., date range).
+        previous_label: Label for the previous period.
+
+    Returns:
+        Formatted markdown comparison table.
+    """
+    if not current and not previous:
+        return "No insights data found for either period."
+
+    metrics = [
+        ("Impressions", "impressions", "int"),
+        ("Clicks", "clicks", "int"),
+        ("Spend", "spend", "dollar"),
+        ("CTR", "ctr", "pct"),
+        ("CPC", "cpc", "dollar"),
+        ("CPM", "cpm", "dollar"),
+        ("Reach", "reach", "int"),
+    ]
+
+    lines = [
+        "## Period Comparison",
+        "",
+        f"| Metric | {current_label} | {previous_label} | Change | Change % |",
+        "|---|---|---|---|---|",
+    ]
+
+    for label, field, fmt in metrics:
+        cur_val = float(getattr(current, field, "0")) if current else 0.0
+        prev_val = float(getattr(previous, field, "0")) if previous else 0.0
+        delta = cur_val - prev_val
+        pct = (delta / prev_val * 100) if prev_val != 0 else 0.0
+
+        if fmt == "dollar":
+            cur_str = f"${cur_val:,.2f}"
+            prev_str = f"${prev_val:,.2f}"
+            delta_str = f"${delta:+,.2f}"
+        elif fmt == "pct":
+            cur_str = f"{cur_val:.2f}%"
+            prev_str = f"{prev_val:.2f}%"
+            delta_str = f"{delta:+.2f}%"
+        else:
+            cur_str = f"{int(cur_val):,}"
+            prev_str = f"{int(prev_val):,}"
+            delta_str = f"{int(delta):+,}"
+
+        pct_str = f"{pct:+.1f}%" if prev_val != 0 else "N/A"
+        lines.append(f"| {label} | {cur_str} | {prev_str} | {delta_str} | {pct_str} |")
+
+    return "\n".join(lines)
+
+
+def format_performance_comparison(
+    rows_by_entity: dict[str, InsightRow],
+    entity_type: str,
+) -> str:
+    """Format a side-by-side performance comparison across multiple entities.
+
+    Shows metrics as rows with one column per entity.
+
+    Args:
+        rows_by_entity: Mapping of entity name/label to insight row.
+        entity_type: Type of entity being compared (campaign, adset, ad).
+
+    Returns:
+        Formatted markdown comparison table.
+    """
+    if not rows_by_entity:
+        return f"No data to compare for {entity_type}s."
+
+    entities = list(rows_by_entity.keys())
+    rows = list(rows_by_entity.values())
+
+    metrics = [
+        ("Impressions", "impressions", "int"),
+        ("Clicks", "clicks", "int"),
+        ("Spend", "spend", "dollar"),
+        ("CTR", "ctr", "pct"),
+        ("CPC", "cpc", "dollar"),
+        ("CPM", "cpm", "dollar"),
+        ("Reach", "reach", "int"),
+    ]
+
+    header = "| Metric | " + " | ".join(entities) + " |"
+    separator = "|---|" + "|".join(["---"] * len(entities)) + "|"
+    lines = [
+        f"## {entity_type.title()} Performance Comparison",
+        "",
+        header,
+        separator,
+    ]
+
+    for label, field, fmt in metrics:
+        cells = [label]
+        for row in rows:
+            val = float(getattr(row, field, "0"))
+            if fmt == "dollar":
+                cells.append(f"${val:,.2f}")
+            elif fmt == "pct":
+                cells.append(f"{val:.2f}%")
+            else:
+                cells.append(f"{int(val):,}")
+        lines.append("| " + " | ".join(cells) + " |")
+
+    return "\n".join(lines)
+
+
 def format_error(message: str) -> str:
     """Format an error message as markdown.
 

--- a/src/meta_ads_mcp/server.py
+++ b/src/meta_ads_mcp/server.py
@@ -13,6 +13,15 @@ from mcp.server.fastmcp import FastMCP
 
 from meta_ads_mcp.client import MetaAdsClient
 from meta_ads_mcp.config import MetaAdsConfig
+from meta_ads_mcp.tools import (
+    accounts,
+    ads,
+    adsets,
+    audiences,
+    campaigns,
+    creatives,
+    insights,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +61,15 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 
 
 mcp = FastMCP("Meta Ads MCP", lifespan=app_lifespan)
+
+# Register all tool modules
+accounts.register(mcp)
+campaigns.register(mcp)
+adsets.register(mcp)
+ads.register(mcp)
+insights.register(mcp)
+creatives.register(mcp)
+audiences.register(mcp)
 
 
 def main() -> None:

--- a/src/meta_ads_mcp/tools/__init__.py
+++ b/src/meta_ads_mcp/tools/__init__.py
@@ -1,1 +1,17 @@
 """MCP tool modules organized by Meta Ads entity type."""
+
+from mcp.server.fastmcp import Context
+
+from meta_ads_mcp.client import MetaAdsClient
+
+
+def get_client(ctx: Context) -> MetaAdsClient:
+    """Extract MetaAdsClient from MCP request context.
+
+    Args:
+        ctx: The MCP tool execution context.
+
+    Returns:
+        The initialized MetaAdsClient from the server lifespan.
+    """
+    return ctx.request_context.lifespan_context.client  # type: ignore[no-any-return]

--- a/src/meta_ads_mcp/tools/_insights_helpers.py
+++ b/src/meta_ads_mcp/tools/_insights_helpers.py
@@ -1,0 +1,70 @@
+"""Date range resolution and period comparison helpers for insights tools."""
+
+from datetime import date, datetime, timedelta
+
+VALID_BREAKDOWNS = frozenset(
+    {
+        "age",
+        "gender",
+        "country",
+        "placement",
+        "device_platform",
+        "publisher_platform",
+    }
+)
+
+
+def resolve_date_preset(preset: str) -> tuple[str, str]:
+    """Map a date preset like 'last_7d' to (since, until) date strings.
+
+    Args:
+        preset: A Meta Ads date preset string.
+
+    Returns:
+        Tuple of (since, until) in YYYY-MM-DD format.
+
+    Raises:
+        ValueError: If the preset is not recognized.
+    """
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+
+    presets: dict[str, tuple[date, date]] = {
+        "today": (today, today),
+        "yesterday": (yesterday, yesterday),
+        "last_7d": (today - timedelta(days=7), yesterday),
+        "last_14d": (today - timedelta(days=14), yesterday),
+        "last_30d": (today - timedelta(days=30), yesterday),
+        "this_month": (today.replace(day=1), today),
+        "last_month": (
+            (today.replace(day=1) - timedelta(days=1)).replace(day=1),
+            today.replace(day=1) - timedelta(days=1),
+        ),
+    }
+
+    if preset not in presets:
+        raise ValueError(
+            f"Unknown date preset '{preset}'. "
+            f"Valid presets: {', '.join(sorted(presets))}"
+        )
+
+    since, until = presets[preset]
+    return since.isoformat(), until.isoformat()
+
+
+def get_previous_range(since: str, until: str) -> tuple[str, str]:
+    """Shift a date range back by its duration for period-over-period comparison.
+
+    Args:
+        since: Start date in YYYY-MM-DD format.
+        until: End date in YYYY-MM-DD format.
+
+    Returns:
+        Tuple of (previous_since, previous_until) in YYYY-MM-DD format.
+    """
+    start = datetime.strptime(since, "%Y-%m-%d").date()
+    end = datetime.strptime(until, "%Y-%m-%d").date()
+    duration = (end - start).days + 1
+    prev_end = start - timedelta(days=1)
+    prev_start = prev_end - timedelta(days=duration - 1)
+    return prev_start.isoformat(), prev_end.isoformat()

--- a/src/meta_ads_mcp/tools/accounts.py
+++ b/src/meta_ads_mcp/tools/accounts.py
@@ -1,1 +1,50 @@
 """Account listing and info tools."""
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.formatting import format_account, format_account_list, format_error
+from meta_ads_mcp.models import AdAccountModel
+from meta_ads_mcp.tools import get_client
+
+
+async def get_ad_accounts(ctx: Context) -> str:
+    """List all accessible ad accounts for the authenticated user.
+
+    Returns a table of ad accounts with ID, name, status, currency, and amount spent.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_ad_accounts()
+        models = [AdAccountModel(**d) for d in raw]
+        return format_account_list(models)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+async def get_account_info(ctx: Context, account_id: str | None = None) -> str:
+    """Get detailed information for a specific ad account.
+
+    Shows account name, status, currency, timezone, spend, balance, and spend cap.
+    If no account_id is provided, uses the default configured account.
+
+    Args:
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_account_info(account_id)
+        model = AdAccountModel(**raw)
+        return format_account(model)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register account tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance.
+    """
+    mcp.tool()(get_ad_accounts)
+    mcp.tool()(get_account_info)

--- a/src/meta_ads_mcp/tools/ads.py
+++ b/src/meta_ads_mcp/tools/ads.py
@@ -1,1 +1,72 @@
 """Ad management tools."""
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.formatting import format_ad, format_ad_list, format_error
+from meta_ads_mcp.models import AdModel
+from meta_ads_mcp.tools import get_client
+
+
+async def list_ads(
+    ctx: Context,
+    account_id: str | None = None,
+    ad_set_id: str | None = None,
+    campaign_id: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+) -> str:
+    """List ads for an ad account, campaign, or ad set.
+
+    Returns a table of ads with ID, name, status, ad set, and creative reference.
+    Filter by ad_set_id or campaign_id to narrow results, or by status.
+
+    Args:
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+        ad_set_id: Filter to ads in this ad set. Optional.
+        campaign_id: Filter to ads in this campaign. Optional.
+        status: Filter by effective status (e.g., ACTIVE, PAUSED). Optional.
+        limit: Maximum number of ads to return. Default 50.
+    """
+    try:
+        client = get_client(ctx)
+        status_filter = [status] if status else None
+        raw = await client.get_ads(
+            account_id=account_id,
+            ad_set_id=ad_set_id,
+            campaign_id=campaign_id,
+            status_filter=status_filter,
+            limit=limit,
+        )
+        models = [AdModel(**d) for d in raw]
+        return format_ad_list(models)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+async def get_ad(ctx: Context, ad_id: str) -> str:
+    """Get detailed information for a specific ad.
+
+    Shows ad name, status, parent ad set and campaign,
+    creative reference, and timestamps.
+
+    Args:
+        ad_id: The ad ID.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_ad(ad_id)
+        model = AdModel(**raw)
+        return format_ad(model)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register ad tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance.
+    """
+    mcp.tool()(list_ads)
+    mcp.tool()(get_ad)

--- a/src/meta_ads_mcp/tools/adsets.py
+++ b/src/meta_ads_mcp/tools/adsets.py
@@ -1,1 +1,69 @@
 """Ad set management tools."""
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.formatting import format_ad_set, format_ad_set_list, format_error
+from meta_ads_mcp.models import AdSetModel
+from meta_ads_mcp.tools import get_client
+
+
+async def list_ad_sets(
+    ctx: Context,
+    account_id: str | None = None,
+    campaign_id: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+) -> str:
+    """List ad sets for an ad account or specific campaign.
+
+    Returns a table of ad sets with ID, name, status, campaign, budget,
+    and optimization goal. Filter by campaign_id or status.
+
+    Args:
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+        campaign_id: Filter to ad sets in this campaign. Optional.
+        status: Filter by effective status (e.g., ACTIVE, PAUSED). Optional.
+        limit: Maximum number of ad sets to return. Default 50.
+    """
+    try:
+        client = get_client(ctx)
+        status_filter = [status] if status else None
+        raw = await client.get_ad_sets(
+            account_id=account_id,
+            campaign_id=campaign_id,
+            status_filter=status_filter,
+            limit=limit,
+        )
+        models = [AdSetModel(**d) for d in raw]
+        return format_ad_set_list(models)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+async def get_ad_set(ctx: Context, ad_set_id: str) -> str:
+    """Get detailed information for a specific ad set.
+
+    Shows ad set name, status, campaign, budgets, billing,
+    optimization, targeting, and schedule.
+
+    Args:
+        ad_set_id: The ad set ID.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_ad_set(ad_set_id)
+        model = AdSetModel(**raw)
+        return format_ad_set(model)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register ad set tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance.
+    """
+    mcp.tool()(list_ad_sets)
+    mcp.tool()(get_ad_set)

--- a/src/meta_ads_mcp/tools/audiences.py
+++ b/src/meta_ads_mcp/tools/audiences.py
@@ -1,1 +1,62 @@
 """Audience management tools."""
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.formatting import (
+    format_audience,
+    format_audience_list,
+    format_error,
+)
+from meta_ads_mcp.models import CustomAudienceModel
+from meta_ads_mcp.tools import get_client
+
+
+async def list_audiences(
+    ctx: Context,
+    account_id: str | None = None,
+    limit: int = 50,
+) -> str:
+    """List custom and lookalike audiences for an ad account.
+
+    Returns a table of audiences with ID, name, subtype, size, and description.
+
+    Args:
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+        limit: Maximum number of audiences to return. Default 50.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_audiences(account_id=account_id, limit=limit)
+        models = [CustomAudienceModel(**d) for d in raw]
+        return format_audience_list(models)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+async def get_audience(ctx: Context, audience_id: str) -> str:
+    """Get detailed information for a specific custom audience.
+
+    Shows audience name, subtype, size range, delivery status,
+    operation status, and description.
+
+    Args:
+        audience_id: The audience ID.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_audience(audience_id)
+        model = CustomAudienceModel(**raw)
+        return format_audience(model)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register audience tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance.
+    """
+    mcp.tool()(list_audiences)
+    mcp.tool()(get_audience)

--- a/src/meta_ads_mcp/tools/campaigns.py
+++ b/src/meta_ads_mcp/tools/campaigns.py
@@ -1,1 +1,67 @@
 """Campaign management tools."""
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.formatting import (
+    format_campaign,
+    format_campaign_list,
+    format_error,
+)
+from meta_ads_mcp.models import CampaignModel
+from meta_ads_mcp.tools import get_client
+
+
+async def list_campaigns(
+    ctx: Context,
+    account_id: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+) -> str:
+    """List campaigns for an ad account.
+
+    Returns a table of campaigns with ID, name, status, objective, and budget.
+    Optionally filter by status (ACTIVE, PAUSED, ARCHIVED).
+
+    Args:
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+        status: Filter by effective status (e.g., ACTIVE, PAUSED). Optional.
+        limit: Maximum number of campaigns to return. Default 50.
+    """
+    try:
+        client = get_client(ctx)
+        status_filter = [status] if status else None
+        raw = await client.get_campaigns(
+            account_id=account_id, status_filter=status_filter, limit=limit
+        )
+        models = [CampaignModel(**d) for d in raw]
+        return format_campaign_list(models)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+async def get_campaign(ctx: Context, campaign_id: str) -> str:
+    """Get detailed information for a specific campaign.
+
+    Shows campaign name, status, objective, budgets, and schedule.
+
+    Args:
+        campaign_id: The campaign ID.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_campaign(campaign_id)
+        model = CampaignModel(**raw)
+        return format_campaign(model)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register campaign tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance.
+    """
+    mcp.tool()(list_campaigns)
+    mcp.tool()(get_campaign)

--- a/src/meta_ads_mcp/tools/creatives.py
+++ b/src/meta_ads_mcp/tools/creatives.py
@@ -1,1 +1,61 @@
 """Creative management tools."""
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.formatting import (
+    format_creative,
+    format_creative_list,
+    format_error,
+)
+from meta_ads_mcp.models import AdCreativeModel
+from meta_ads_mcp.tools import get_client
+
+
+async def list_creatives(
+    ctx: Context,
+    account_id: str | None = None,
+    limit: int = 50,
+) -> str:
+    """List ad creatives for an ad account.
+
+    Returns a table of creatives with ID, name, title, CTA, and link URL.
+
+    Args:
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+        limit: Maximum number of creatives to return. Default 50.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_creatives(account_id=account_id, limit=limit)
+        models = [AdCreativeModel(**d) for d in raw]
+        return format_creative_list(models)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+async def get_creative(ctx: Context, creative_id: str) -> str:
+    """Get detailed information for a specific ad creative.
+
+    Shows creative name, title, body, CTA, link URL, image URL, and thumbnail.
+
+    Args:
+        creative_id: The creative ID.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_creative(creative_id)
+        model = AdCreativeModel(**raw)
+        return format_creative(model)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register creative tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance.
+    """
+    mcp.tool()(list_creatives)
+    mcp.tool()(get_creative)

--- a/src/meta_ads_mcp/tools/insights.py
+++ b/src/meta_ads_mcp/tools/insights.py
@@ -1,1 +1,275 @@
 """Performance reporting and analytics tools."""
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.formatting import (
+    format_error,
+    format_insights_comparison,
+    format_insights_table,
+    format_performance_comparison,
+)
+from meta_ads_mcp.models import InsightRow
+from meta_ads_mcp.tools import get_client
+from meta_ads_mcp.tools._insights_helpers import (
+    VALID_BREAKDOWNS,
+    get_previous_range,
+    resolve_date_preset,
+)
+
+
+async def get_insights(
+    ctx: Context,
+    account_id: str | None = None,
+    date_preset: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    level: str = "account",
+    breakdowns: str | None = None,
+    fields: str | None = None,
+    limit: int = 50,
+) -> str:
+    """Get performance insights with flexible options.
+
+    Query ad account insights at any aggregation level with
+    optional breakdowns. Provide either date_preset or
+    start_date + end_date.
+
+    Args:
+        account_id: Ad account ID (e.g., act_123456789).
+        date_preset: Date preset (today, yesterday, last_7d,
+            last_14d, last_30d, this_month, last_month).
+        start_date: Start date YYYY-MM-DD, use with end_date.
+        end_date: End date YYYY-MM-DD, use with start_date.
+        level: Aggregation level: account, campaign, adset, ad.
+        breakdowns: Comma-separated breakdowns (age, gender,
+            country, placement, device_platform,
+            publisher_platform).
+        fields: Comma-separated metric fields to retrieve.
+        limit: Maximum rows to return. Default 50.
+    """
+    try:
+        client = get_client(ctx)
+        time_range = None
+        if start_date and end_date:
+            time_range = {"since": start_date, "until": end_date}
+        breakdown_list = (
+            [b.strip() for b in breakdowns.split(",")] if breakdowns else None
+        )
+        field_list = [f.strip() for f in fields.split(",")] if fields else None
+        raw = await client.get_insights(
+            account_id=account_id,
+            date_preset=date_preset if not time_range else None,
+            level=level,
+            breakdowns=breakdown_list,
+            fields=field_list,
+            time_range=time_range,
+            limit=limit,
+        )
+        models = [InsightRow(**d) for d in raw]
+        return format_insights_table(models)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+async def get_account_insights(
+    ctx: Context,
+    account_id: str | None = None,
+    date_preset: str = "last_30d",
+) -> str:
+    """Get account-level performance summary.
+
+    Returns key metrics (impressions, clicks, spend, CTR, CPC,
+    CPM, reach) for the entire ad account.
+
+    Args:
+        account_id: Ad account ID (e.g., act_123456789).
+        date_preset: Date preset (e.g., last_7d, last_30d).
+    """
+    return await get_insights(
+        ctx, account_id=account_id, date_preset=date_preset, level="account"
+    )
+
+
+async def get_campaign_insights(
+    ctx: Context,
+    campaign_id: str,
+    date_preset: str = "last_30d",
+    compare: bool = False,
+    account_id: str | None = None,
+) -> str:
+    """Get campaign performance with optional period comparison.
+
+    Without compare: returns metrics for the date range.
+    With compare=True: shows current vs. previous period
+    side-by-side with change amounts and percentages.
+
+    Args:
+        campaign_id: The campaign ID to get insights for.
+        date_preset: Date preset (e.g., last_7d, last_30d).
+        compare: Compare current to previous period.
+        account_id: Ad account ID (e.g., act_123456789).
+    """
+    try:
+        client = get_client(ctx)
+        since, until = resolve_date_preset(date_preset)
+        time_range = {"since": since, "until": until}
+
+        raw = await client.get_insights(
+            account_id=account_id,
+            level="campaign",
+            time_range=time_range,
+            limit=100,
+        )
+        current = [InsightRow(**d) for d in raw if d.get("campaign_id") == campaign_id]
+
+        if not compare:
+            if not current:
+                return f"No insights found for campaign {campaign_id}."
+            return format_insights_table(
+                current, title=f"Campaign {campaign_id} Insights"
+            )
+
+        prev_since, prev_until = get_previous_range(since, until)
+        prev_time_range = {"since": prev_since, "until": prev_until}
+
+        raw_prev = await client.get_insights(
+            account_id=account_id,
+            level="campaign",
+            time_range=prev_time_range,
+            limit=100,
+        )
+        previous = [
+            InsightRow(**d) for d in raw_prev if d.get("campaign_id") == campaign_id
+        ]
+
+        current_label = f"{since} to {until}"
+        previous_label = f"{prev_since} to {prev_until}"
+
+        return format_insights_comparison(
+            current=current[0] if current else None,
+            previous=previous[0] if previous else None,
+            current_label=current_label,
+            previous_label=previous_label,
+        )
+    except (MetaAdsError, ValueError) as e:
+        return format_error(str(e))
+
+
+async def compare_performance(
+    ctx: Context,
+    entity_ids: str,
+    entity_type: str = "campaign",
+    date_preset: str = "last_30d",
+    account_id: str | None = None,
+) -> str:
+    """Compare performance across multiple entities side-by-side.
+
+    Fetches insights for each entity and displays them in a
+    comparison table.
+
+    Args:
+        entity_ids: Comma-separated IDs (e.g., "123,456,789").
+        entity_type: campaign, adset, or ad. Default campaign.
+        date_preset: Date preset (e.g., last_7d, last_30d).
+        account_id: Ad account ID (e.g., act_123456789).
+    """
+    try:
+        client = get_client(ctx)
+        ids = [eid.strip() for eid in entity_ids.split(",")]
+
+        level_map = {
+            "campaign": "campaign",
+            "adset": "adset",
+            "ad": "ad",
+        }
+        level = level_map.get(entity_type)
+        if not level:
+            return format_error(
+                f"Invalid entity_type '{entity_type}'. "
+                f"Must be campaign, adset, or ad."
+            )
+
+        id_field = f"{entity_type}_id"
+        name_field = f"{entity_type}_name"
+
+        since, until = resolve_date_preset(date_preset)
+        time_range = {"since": since, "until": until}
+
+        raw = await client.get_insights(
+            account_id=account_id,
+            level=level,
+            time_range=time_range,
+            limit=200,
+        )
+        all_rows = [InsightRow(**d) for d in raw]
+
+        rows_by_entity: dict[str, InsightRow] = {}
+        for row in all_rows:
+            row_id = getattr(row, id_field, "")
+            if row_id in ids:
+                label = getattr(row, name_field, "") or row_id
+                rows_by_entity[label] = row
+
+        if not rows_by_entity:
+            return f"No insights found for the specified {entity_type}s."
+
+        return format_performance_comparison(rows_by_entity, entity_type)
+    except (MetaAdsError, ValueError) as e:
+        return format_error(str(e))
+
+
+async def get_breakdown_report(
+    ctx: Context,
+    breakdown: str,
+    account_id: str | None = None,
+    date_preset: str = "last_30d",
+    level: str = "account",
+    limit: int = 50,
+) -> str:
+    """Get a performance report broken down by a dimension.
+
+    Breaks down metrics by age, gender, country, placement,
+    device_platform, or publisher_platform.
+
+    Args:
+        breakdown: Breakdown dimension (age, gender, country,
+            placement, device_platform, publisher_platform).
+        account_id: Ad account ID (e.g., act_123456789).
+        date_preset: Date preset (e.g., last_7d, last_30d).
+        level: Aggregation level: account, campaign, adset, ad.
+        limit: Maximum rows to return. Default 50.
+    """
+    if breakdown not in VALID_BREAKDOWNS:
+        return format_error(
+            f"Invalid breakdown '{breakdown}'. "
+            f"Valid options: {', '.join(sorted(VALID_BREAKDOWNS))}"
+        )
+
+    try:
+        client = get_client(ctx)
+        raw = await client.get_insights(
+            account_id=account_id,
+            date_preset=date_preset,
+            level=level,
+            breakdowns=[breakdown],
+            limit=limit,
+        )
+        models = [InsightRow(**d) for d in raw]
+        title = f"Breakdown by {breakdown.replace('_', ' ').title()}"
+        return format_insights_table(models, title=title)
+    except MetaAdsError as e:
+        return format_error(e.message)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register insights tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance.
+    """
+    mcp.tool()(get_insights)
+    mcp.tool()(get_account_insights)
+    mcp.tool()(get_campaign_insights)
+    mcp.tool()(compare_performance)
+    mcp.tool()(get_breakdown_report)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared test fixtures for tool tests."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from meta_ads_mcp.client import MetaAdsClient
+
+
+@pytest.fixture
+def mock_client() -> AsyncMock:
+    """Create a mock MetaAdsClient with all async methods."""
+    return AsyncMock(spec=MetaAdsClient)
+
+
+@pytest.fixture
+def mock_context(mock_client: AsyncMock) -> MagicMock:
+    """Create a mock MCP Context with the mock client wired in."""
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context.client = mock_client
+    return ctx

--- a/tests/test_tools_accounts.py
+++ b/tests/test_tools_accounts.py
@@ -1,0 +1,113 @@
+"""Tests for account tools."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.tools.accounts import get_account_info, get_ad_accounts
+
+
+class TestGetAdAccounts:
+    """Tests for get_ad_accounts tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted account list."""
+        mock_client.get_ad_accounts.return_value = [
+            {
+                "id": "act_111",
+                "name": "Account One",
+                "account_status": 1,
+                "currency": "USD",
+                "timezone_name": "America/New_York",
+                "amount_spent": "50000",
+            },
+            {
+                "id": "act_222",
+                "name": "Account Two",
+                "account_status": 2,
+                "currency": "EUR",
+                "amount_spent": "10000",
+            },
+        ]
+
+        result = await get_ad_accounts(mock_context)
+
+        assert "## Ad Accounts" in result
+        assert "act_111" in result
+        assert "Account One" in result
+        assert "act_222" in result
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns empty message when no accounts."""
+        mock_client.get_ad_accounts.return_value = []
+
+        result = await get_ad_accounts(mock_context)
+
+        assert "No ad accounts found" in result
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_ad_accounts.side_effect = MetaAdsError("Invalid token")
+
+        result = await get_ad_accounts(mock_context)
+
+        assert "## Error" in result
+        assert "Invalid token" in result
+
+
+class TestGetAccountInfo:
+    """Tests for get_account_info tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted account detail."""
+        mock_client.get_account_info.return_value = {
+            "id": "act_123",
+            "name": "My Agency Account",
+            "account_status": 1,
+            "currency": "USD",
+            "timezone_name": "America/New_York",
+            "amount_spent": "150000",
+            "balance": "5000",
+            "spend_cap": "1000000",
+        }
+
+        result = await get_account_info(mock_context, account_id="act_123")
+
+        assert "## Ad Account: My Agency Account" in result
+        assert "act_123" in result
+        assert "$1,500.00" in result
+        mock_client.get_account_info.assert_called_once_with("act_123")
+
+    @pytest.mark.asyncio
+    async def test_default_account(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Passes None when no account_id given."""
+        mock_client.get_account_info.return_value = {
+            "id": "act_default",
+            "name": "Default",
+            "account_status": 1,
+        }
+
+        await get_account_info(mock_context)
+
+        mock_client.get_account_info.assert_called_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_account_info.side_effect = MetaAdsError("Not found")
+
+        result = await get_account_info(mock_context, account_id="act_bad")
+
+        assert "## Error" in result
+        assert "Not found" in result

--- a/tests/test_tools_ads.py
+++ b/tests/test_tools_ads.py
@@ -1,0 +1,114 @@
+"""Tests for ad tools."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.tools.ads import get_ad, list_ads
+
+
+class TestListAds:
+    """Tests for list_ads tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted ad list."""
+        mock_client.get_ads.return_value = [
+            {
+                "id": "ad_1",
+                "name": "Ad Variant A",
+                "status": "ACTIVE",
+                "effective_status": "ACTIVE",
+                "adset_id": "adset_1",
+                "campaign_id": "camp_1",
+                "creative": {"id": "cr_1"},
+            },
+        ]
+
+        result = await list_ads(mock_context)
+
+        assert "## Ads" in result
+        assert "Ad Variant A" in result
+        assert "cr_1" in result
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns empty message when no ads."""
+        mock_client.get_ads.return_value = []
+
+        result = await list_ads(mock_context)
+
+        assert "No ads found" in result
+
+    @pytest.mark.asyncio
+    async def test_filters(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Passes all filters to client."""
+        mock_client.get_ads.return_value = []
+
+        await list_ads(
+            mock_context,
+            ad_set_id="adset_1",
+            campaign_id="camp_1",
+            status="ACTIVE",
+            limit=20,
+        )
+
+        mock_client.get_ads.assert_called_once_with(
+            account_id=None,
+            ad_set_id="adset_1",
+            campaign_id="camp_1",
+            status_filter=["ACTIVE"],
+            limit=20,
+        )
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_ads.side_effect = MetaAdsError("API error")
+
+        result = await list_ads(mock_context)
+
+        assert "## Error" in result
+        assert "API error" in result
+
+
+class TestGetAd:
+    """Tests for get_ad tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted ad detail."""
+        mock_client.get_ad.return_value = {
+            "id": "ad_123",
+            "name": "Hero Image Ad",
+            "status": "ACTIVE",
+            "effective_status": "ACTIVE",
+            "adset_id": "adset_456",
+            "campaign_id": "camp_789",
+            "creative": {"id": "cr_111"},
+            "created_time": "2026-03-01T00:00:00",
+        }
+
+        result = await get_ad(mock_context, ad_id="ad_123")
+
+        assert "## Ad: Hero Image Ad" in result
+        assert "cr_111" in result
+        assert "adset_456" in result
+        mock_client.get_ad.assert_called_once_with("ad_123")
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_ad.side_effect = MetaAdsError("Ad not found")
+
+        result = await get_ad(mock_context, ad_id="ad_bad")
+
+        assert "## Error" in result
+        assert "Ad not found" in result

--- a/tests/test_tools_adsets.py
+++ b/tests/test_tools_adsets.py
@@ -1,0 +1,111 @@
+"""Tests for ad set tools."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.tools.adsets import get_ad_set, list_ad_sets
+
+
+class TestListAdSets:
+    """Tests for list_ad_sets tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted ad set list."""
+        mock_client.get_ad_sets.return_value = [
+            {
+                "id": "adset_1",
+                "name": "US Targeting",
+                "status": "ACTIVE",
+                "effective_status": "ACTIVE",
+                "campaign_id": "camp_1",
+                "daily_budget": "2500",
+                "optimization_goal": "LINK_CLICKS",
+            },
+        ]
+
+        result = await list_ad_sets(mock_context)
+
+        assert "## Ad Sets" in result
+        assert "US Targeting" in result
+        assert "LINK_CLICKS" in result
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns empty message when no ad sets."""
+        mock_client.get_ad_sets.return_value = []
+
+        result = await list_ad_sets(mock_context)
+
+        assert "No ad sets found" in result
+
+    @pytest.mark.asyncio
+    async def test_campaign_filter(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Passes campaign_id and status filter to client."""
+        mock_client.get_ad_sets.return_value = []
+
+        await list_ad_sets(
+            mock_context, campaign_id="camp_1", status="PAUSED", limit=25
+        )
+
+        mock_client.get_ad_sets.assert_called_once_with(
+            account_id=None,
+            campaign_id="camp_1",
+            status_filter=["PAUSED"],
+            limit=25,
+        )
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_ad_sets.side_effect = MetaAdsError("Rate limit reached")
+
+        result = await list_ad_sets(mock_context)
+
+        assert "## Error" in result
+        assert "Rate limit reached" in result
+
+
+class TestGetAdSet:
+    """Tests for get_ad_set tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted ad set detail."""
+        mock_client.get_ad_set.return_value = {
+            "id": "adset_123",
+            "name": "Age 25-34",
+            "status": "ACTIVE",
+            "effective_status": "ACTIVE",
+            "campaign_id": "camp_456",
+            "daily_budget": "3000",
+            "billing_event": "IMPRESSIONS",
+            "optimization_goal": "REACH",
+            "targeting": {"geo_locations": {"countries": ["US", "CA"]}},
+        }
+
+        result = await get_ad_set(mock_context, ad_set_id="adset_123")
+
+        assert "## Ad Set: Age 25-34" in result
+        assert "camp_456" in result
+        assert "$30.00" in result
+        assert "REACH" in result
+        mock_client.get_ad_set.assert_called_once_with("adset_123")
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_ad_set.side_effect = MetaAdsError("Ad set not found")
+
+        result = await get_ad_set(mock_context, ad_set_id="adset_bad")
+
+        assert "## Error" in result
+        assert "Ad set not found" in result

--- a/tests/test_tools_audiences.py
+++ b/tests/test_tools_audiences.py
@@ -1,0 +1,104 @@
+"""Tests for audience tools."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.tools.audiences import get_audience, list_audiences
+
+
+class TestListAudiences:
+    """Tests for list_audiences tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted audience list."""
+        mock_client.get_audiences.return_value = [
+            {
+                "id": "aud_1",
+                "name": "Website Visitors",
+                "subtype": "CUSTOM",
+                "approximate_count_lower_bound": 10000,
+                "approximate_count_upper_bound": 15000,
+                "description": "Last 30 day visitors",
+            },
+        ]
+
+        result = await list_audiences(mock_context)
+
+        assert "## Custom Audiences" in result
+        assert "Website Visitors" in result
+        assert "CUSTOM" in result
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns empty message when no audiences."""
+        mock_client.get_audiences.return_value = []
+
+        result = await list_audiences(mock_context)
+
+        assert "No audiences found" in result
+
+    @pytest.mark.asyncio
+    async def test_params(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Passes parameters to client."""
+        mock_client.get_audiences.return_value = []
+
+        await list_audiences(mock_context, account_id="act_123", limit=10)
+
+        mock_client.get_audiences.assert_called_once_with(
+            account_id="act_123", limit=10
+        )
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_audiences.side_effect = MetaAdsError("Forbidden")
+
+        result = await list_audiences(mock_context)
+
+        assert "## Error" in result
+        assert "Forbidden" in result
+
+
+class TestGetAudience:
+    """Tests for get_audience tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted audience detail."""
+        mock_client.get_audience.return_value = {
+            "id": "aud_123",
+            "name": "Lookalike US 1%",
+            "subtype": "LOOKALIKE",
+            "approximate_count_lower_bound": 2000000,
+            "approximate_count_upper_bound": 2500000,
+            "delivery_status": {"status": "ready"},
+            "operation_status": {"status": "normal"},
+            "description": "Top 1% lookalike from website visitors",
+        }
+
+        result = await get_audience(mock_context, audience_id="aud_123")
+
+        assert "## Audience: Lookalike US 1%" in result
+        assert "LOOKALIKE" in result
+        assert "2,000,000 - 2,500,000" in result
+        assert "ready" in result
+        mock_client.get_audience.assert_called_once_with("aud_123")
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_audience.side_effect = MetaAdsError("Audience not found")
+
+        result = await get_audience(mock_context, audience_id="aud_bad")
+
+        assert "## Error" in result
+        assert "Audience not found" in result

--- a/tests/test_tools_campaigns.py
+++ b/tests/test_tools_campaigns.py
@@ -1,0 +1,102 @@
+"""Tests for campaign tools."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.tools.campaigns import get_campaign, list_campaigns
+
+
+class TestListCampaigns:
+    """Tests for list_campaigns tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted campaign list."""
+        mock_client.get_campaigns.return_value = [
+            {
+                "id": "camp_1",
+                "name": "Spring Sale",
+                "status": "ACTIVE",
+                "effective_status": "ACTIVE",
+                "objective": "OUTCOME_TRAFFIC",
+                "daily_budget": "5000",
+            },
+        ]
+
+        result = await list_campaigns(mock_context)
+
+        assert "## Campaigns" in result
+        assert "Spring Sale" in result
+        assert "OUTCOME_TRAFFIC" in result
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns empty message when no campaigns."""
+        mock_client.get_campaigns.return_value = []
+
+        result = await list_campaigns(mock_context)
+
+        assert "No campaigns found" in result
+
+    @pytest.mark.asyncio
+    async def test_status_filter(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Passes status filter to client."""
+        mock_client.get_campaigns.return_value = []
+
+        await list_campaigns(mock_context, status="ACTIVE", limit=10)
+
+        mock_client.get_campaigns.assert_called_once_with(
+            account_id=None, status_filter=["ACTIVE"], limit=10
+        )
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_campaigns.side_effect = MetaAdsError("Permission denied")
+
+        result = await list_campaigns(mock_context)
+
+        assert "## Error" in result
+        assert "Permission denied" in result
+
+
+class TestGetCampaign:
+    """Tests for get_campaign tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted campaign detail."""
+        mock_client.get_campaign.return_value = {
+            "id": "camp_123",
+            "name": "Summer Push",
+            "status": "ACTIVE",
+            "effective_status": "ACTIVE",
+            "objective": "OUTCOME_SALES",
+            "daily_budget": "10000",
+            "start_time": "2026-03-01T00:00:00",
+        }
+
+        result = await get_campaign(mock_context, campaign_id="camp_123")
+
+        assert "## Campaign: Summer Push" in result
+        assert "OUTCOME_SALES" in result
+        assert "$100.00" in result
+        mock_client.get_campaign.assert_called_once_with("camp_123")
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_campaign.side_effect = MetaAdsError("Campaign not found")
+
+        result = await get_campaign(mock_context, campaign_id="camp_bad")
+
+        assert "## Error" in result
+        assert "Campaign not found" in result

--- a/tests/test_tools_creatives.py
+++ b/tests/test_tools_creatives.py
@@ -1,0 +1,103 @@
+"""Tests for creative tools."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.tools.creatives import get_creative, list_creatives
+
+
+class TestListCreatives:
+    """Tests for list_creatives tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted creative list."""
+        mock_client.get_creatives.return_value = [
+            {
+                "id": "cr_1",
+                "name": "Banner Ad",
+                "title": "Shop Now",
+                "call_to_action_type": "SHOP_NOW",
+                "link_url": "https://example.com",
+            },
+        ]
+
+        result = await list_creatives(mock_context)
+
+        assert "## Ad Creatives" in result
+        assert "Banner Ad" in result
+        assert "SHOP_NOW" in result
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns empty message when no creatives."""
+        mock_client.get_creatives.return_value = []
+
+        result = await list_creatives(mock_context)
+
+        assert "No creatives found" in result
+
+    @pytest.mark.asyncio
+    async def test_params(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Passes parameters to client."""
+        mock_client.get_creatives.return_value = []
+
+        await list_creatives(mock_context, account_id="act_123", limit=10)
+
+        mock_client.get_creatives.assert_called_once_with(
+            account_id="act_123", limit=10
+        )
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_creatives.side_effect = MetaAdsError("Access denied")
+
+        result = await list_creatives(mock_context)
+
+        assert "## Error" in result
+        assert "Access denied" in result
+
+
+class TestGetCreative:
+    """Tests for get_creative tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted creative detail."""
+        mock_client.get_creative.return_value = {
+            "id": "cr_123",
+            "name": "Hero Creative",
+            "title": "Big Sale",
+            "body": "Up to 50% off",
+            "call_to_action_type": "LEARN_MORE",
+            "link_url": "https://example.com/sale",
+            "image_url": "https://example.com/img.jpg",
+            "thumbnail_url": "https://example.com/thumb.jpg",
+        }
+
+        result = await get_creative(mock_context, creative_id="cr_123")
+
+        assert "## Creative: Hero Creative" in result
+        assert "Big Sale" in result
+        assert "Up to 50% off" in result
+        assert "LEARN_MORE" in result
+        mock_client.get_creative.assert_called_once_with("cr_123")
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_creative.side_effect = MetaAdsError("Creative not found")
+
+        result = await get_creative(mock_context, creative_id="cr_bad")
+
+        assert "## Error" in result
+        assert "Creative not found" in result

--- a/tests/test_tools_insights.py
+++ b/tests/test_tools_insights.py
@@ -1,0 +1,489 @@
+"""Tests for insight tools and helpers."""
+
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.tools._insights_helpers import (
+    VALID_BREAKDOWNS,
+    get_previous_range,
+    resolve_date_preset,
+)
+from meta_ads_mcp.tools.insights import (
+    compare_performance,
+    get_account_insights,
+    get_breakdown_report,
+    get_campaign_insights,
+    get_insights,
+)
+
+# --- Date helper tests ---
+
+
+class TestResolveDatePreset:
+    """Tests for resolve_date_preset."""
+
+    def test_today(self) -> None:
+        """today maps to today's date for both."""
+        since, until = resolve_date_preset("today")
+        today = date.today().isoformat()
+        assert since == today
+        assert until == today
+
+    def test_yesterday(self) -> None:
+        """yesterday maps to yesterday's date for both."""
+        since, until = resolve_date_preset("yesterday")
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        assert since == yesterday
+        assert until == yesterday
+
+    def test_last_7d(self) -> None:
+        """last_7d covers 7 days ending yesterday."""
+        since, until = resolve_date_preset("last_7d")
+        today = date.today()
+        assert until == (today - timedelta(days=1)).isoformat()
+        assert since == (today - timedelta(days=7)).isoformat()
+
+    def test_last_30d(self) -> None:
+        """last_30d covers 30 days ending yesterday."""
+        since, until = resolve_date_preset("last_30d")
+        today = date.today()
+        assert until == (today - timedelta(days=1)).isoformat()
+        assert since == (today - timedelta(days=30)).isoformat()
+
+    def test_invalid_preset(self) -> None:
+        """Unknown preset raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown date preset"):
+            resolve_date_preset("last_999d")
+
+
+class TestGetPreviousRange:
+    """Tests for get_previous_range."""
+
+    def test_week_range(self) -> None:
+        """7-day range shifts back by 7 days."""
+        prev_since, prev_until = get_previous_range("2026-03-08", "2026-03-14")
+        assert prev_since == "2026-03-01"
+        assert prev_until == "2026-03-07"
+
+    def test_single_day(self) -> None:
+        """Single day shifts back by 1 day."""
+        prev_since, prev_until = get_previous_range("2026-03-10", "2026-03-10")
+        assert prev_since == "2026-03-09"
+        assert prev_until == "2026-03-09"
+
+    def test_month_range(self) -> None:
+        """30-day range shifts back by 30 days."""
+        prev_since, prev_until = get_previous_range("2026-02-01", "2026-03-02")
+        # Duration = 30 days, so previous ends day before start
+        assert prev_until == "2026-01-31"
+
+
+class TestValidBreakdowns:
+    """Tests for VALID_BREAKDOWNS constant."""
+
+    def test_contains_expected(self) -> None:
+        """All expected breakdowns present."""
+        assert "age" in VALID_BREAKDOWNS
+        assert "gender" in VALID_BREAKDOWNS
+        assert "country" in VALID_BREAKDOWNS
+        assert "placement" in VALID_BREAKDOWNS
+        assert "device_platform" in VALID_BREAKDOWNS
+        assert "publisher_platform" in VALID_BREAKDOWNS
+
+
+# --- Tool tests ---
+
+
+class TestGetInsights:
+    """Tests for get_insights tool."""
+
+    @pytest.mark.asyncio
+    async def test_success_with_preset(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted insights table."""
+        mock_client.get_insights.return_value = [
+            {
+                "impressions": "10000",
+                "clicks": "250",
+                "spend": "75.50",
+                "ctr": "2.5",
+                "cpc": "0.302",
+                "cpm": "7.55",
+                "reach": "8000",
+                "date_start": "2026-03-01",
+                "date_stop": "2026-03-07",
+            },
+        ]
+
+        result = await get_insights(mock_context, date_preset="last_7d")
+
+        assert "## Performance Insights" in result
+        assert "10,000" in result
+        assert "$75.50" in result
+
+    @pytest.mark.asyncio
+    async def test_success_with_date_range(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Custom date range passes time_range to client."""
+        mock_client.get_insights.return_value = []
+
+        await get_insights(mock_context, start_date="2026-03-01", end_date="2026-03-07")
+
+        call_kwargs = mock_client.get_insights.call_args.kwargs
+        assert call_kwargs["time_range"] == {
+            "since": "2026-03-01",
+            "until": "2026-03-07",
+        }
+        assert call_kwargs["date_preset"] is None
+
+    @pytest.mark.asyncio
+    async def test_breakdowns_parsed(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Comma-separated breakdowns passed as list."""
+        mock_client.get_insights.return_value = []
+
+        await get_insights(mock_context, breakdowns="age,gender")
+
+        call_kwargs = mock_client.get_insights.call_args.kwargs
+        assert call_kwargs["breakdowns"] == ["age", "gender"]
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns empty message when no data."""
+        mock_client.get_insights.return_value = []
+
+        result = await get_insights(mock_context)
+
+        assert "No insights data found" in result
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_insights.side_effect = MetaAdsError("Rate limit")
+
+        result = await get_insights(mock_context)
+
+        assert "## Error" in result
+        assert "Rate limit" in result
+
+
+class TestGetAccountInsights:
+    """Tests for get_account_insights tool."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_get_insights(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Calls get_insights with account level."""
+        mock_client.get_insights.return_value = [
+            {
+                "impressions": "5000",
+                "clicks": "100",
+                "spend": "30.00",
+                "ctr": "2.0",
+                "cpc": "0.30",
+                "cpm": "6.00",
+                "reach": "4000",
+                "date_start": "2026-02-10",
+                "date_stop": "2026-03-11",
+            },
+        ]
+
+        result = await get_account_insights(mock_context, date_preset="last_30d")
+
+        assert "## Performance Insights" in result
+        call_kwargs = mock_client.get_insights.call_args.kwargs
+        assert call_kwargs["level"] == "account"
+
+
+class TestGetCampaignInsights:
+    """Tests for get_campaign_insights tool."""
+
+    @pytest.mark.asyncio
+    async def test_single_period(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns insights for single period."""
+        mock_client.get_insights.return_value = [
+            {
+                "campaign_id": "camp_1",
+                "campaign_name": "Spring Sale",
+                "impressions": "10000",
+                "clicks": "500",
+                "spend": "100.00",
+                "ctr": "5.0",
+                "cpc": "0.20",
+                "cpm": "10.00",
+                "reach": "8000",
+                "date_start": "2026-02-10",
+                "date_stop": "2026-03-11",
+            },
+        ]
+
+        result = await get_campaign_insights(
+            mock_context, campaign_id="camp_1", date_preset="last_30d"
+        )
+
+        assert "Campaign camp_1 Insights" in result
+        assert "Spring Sale" in result
+
+    @pytest.mark.asyncio
+    async def test_no_data(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns message when campaign has no data."""
+        mock_client.get_insights.return_value = []
+
+        result = await get_campaign_insights(mock_context, campaign_id="camp_999")
+
+        assert "No insights found" in result
+
+    @pytest.mark.asyncio
+    async def test_comparison(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Compare mode makes two API calls and returns comparison."""
+        mock_client.get_insights.side_effect = [
+            # Current period
+            [
+                {
+                    "campaign_id": "camp_1",
+                    "impressions": "10000",
+                    "clicks": "500",
+                    "spend": "100.00",
+                    "ctr": "5.0",
+                    "cpc": "0.20",
+                    "cpm": "10.00",
+                    "reach": "8000",
+                    "date_start": "2026-02-10",
+                    "date_stop": "2026-03-11",
+                },
+            ],
+            # Previous period
+            [
+                {
+                    "campaign_id": "camp_1",
+                    "impressions": "8000",
+                    "clicks": "300",
+                    "spend": "80.00",
+                    "ctr": "3.75",
+                    "cpc": "0.267",
+                    "cpm": "10.00",
+                    "reach": "6000",
+                    "date_start": "2026-01-11",
+                    "date_stop": "2026-02-09",
+                },
+            ],
+        ]
+
+        result = await get_campaign_insights(
+            mock_context,
+            campaign_id="camp_1",
+            date_preset="last_30d",
+            compare=True,
+        )
+
+        assert "## Period Comparison" in result
+        assert "Impressions" in result
+        assert mock_client.get_insights.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_comparison_no_previous(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Comparison with no previous data still produces output."""
+        mock_client.get_insights.side_effect = [
+            [
+                {
+                    "campaign_id": "camp_1",
+                    "impressions": "10000",
+                    "clicks": "500",
+                    "spend": "100.00",
+                    "ctr": "5.0",
+                    "cpc": "0.20",
+                    "cpm": "10.00",
+                    "reach": "8000",
+                    "date_start": "2026-02-10",
+                    "date_stop": "2026-03-11",
+                },
+            ],
+            [],  # No previous data
+        ]
+
+        result = await get_campaign_insights(
+            mock_context, campaign_id="camp_1", compare=True
+        )
+
+        assert "## Period Comparison" in result
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_insights.side_effect = MetaAdsError("Server error")
+
+        result = await get_campaign_insights(mock_context, campaign_id="camp_1")
+
+        assert "## Error" in result
+
+
+class TestComparePerformance:
+    """Tests for compare_performance tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns comparison table for multiple entities."""
+        mock_client.get_insights.return_value = [
+            {
+                "campaign_id": "camp_1",
+                "campaign_name": "Spring Sale",
+                "impressions": "10000",
+                "clicks": "500",
+                "spend": "100.00",
+                "ctr": "5.0",
+                "cpc": "0.20",
+                "cpm": "10.00",
+                "reach": "8000",
+            },
+            {
+                "campaign_id": "camp_2",
+                "campaign_name": "Summer Push",
+                "impressions": "8000",
+                "clicks": "200",
+                "spend": "80.00",
+                "ctr": "2.5",
+                "cpc": "0.40",
+                "cpm": "10.00",
+                "reach": "6000",
+            },
+        ]
+
+        result = await compare_performance(mock_context, entity_ids="camp_1,camp_2")
+
+        assert "## Campaign Performance Comparison" in result
+        assert "Spring Sale" in result
+        assert "Summer Push" in result
+
+    @pytest.mark.asyncio
+    async def test_no_data(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns message when no matching entities."""
+        mock_client.get_insights.return_value = []
+
+        result = await compare_performance(mock_context, entity_ids="camp_999")
+
+        assert "No insights found" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_entity_type(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns error for invalid entity type."""
+        result = await compare_performance(
+            mock_context, entity_ids="123", entity_type="invalid"
+        )
+
+        assert "## Error" in result
+        assert "Invalid entity_type" in result
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_insights.side_effect = MetaAdsError("Timeout")
+
+        result = await compare_performance(mock_context, entity_ids="camp_1")
+
+        assert "## Error" in result
+
+
+class TestGetBreakdownReport:
+    """Tests for get_breakdown_report tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns breakdown table."""
+        mock_client.get_insights.return_value = [
+            {
+                "age": "25-34",
+                "impressions": "5000",
+                "clicks": "200",
+                "spend": "40.00",
+                "ctr": "4.0",
+                "cpc": "0.20",
+                "cpm": "8.00",
+                "reach": "4000",
+                "date_start": "2026-02-10",
+                "date_stop": "2026-03-11",
+            },
+            {
+                "age": "35-44",
+                "impressions": "3000",
+                "clicks": "100",
+                "spend": "30.00",
+                "ctr": "3.33",
+                "cpc": "0.30",
+                "cpm": "10.00",
+                "reach": "2500",
+                "date_start": "2026-02-10",
+                "date_stop": "2026-03-11",
+            },
+        ]
+
+        result = await get_breakdown_report(mock_context, breakdown="age")
+
+        assert "Breakdown by Age" in result
+        assert "25-34" in result
+        assert "35-44" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_breakdown(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns error for invalid breakdown."""
+        result = await get_breakdown_report(mock_context, breakdown="invalid_field")
+
+        assert "## Error" in result
+        assert "Invalid breakdown" in result
+
+    @pytest.mark.asyncio
+    async def test_passes_params(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Passes all parameters to client."""
+        mock_client.get_insights.return_value = []
+
+        await get_breakdown_report(
+            mock_context,
+            breakdown="gender",
+            account_id="act_123",
+            date_preset="last_7d",
+            level="campaign",
+            limit=10,
+        )
+
+        mock_client.get_insights.assert_called_once_with(
+            account_id="act_123",
+            date_preset="last_7d",
+            level="campaign",
+            breakdowns=["gender"],
+            limit=10,
+        )
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_insights.side_effect = MetaAdsError("API error")
+
+        result = await get_breakdown_report(mock_context, breakdown="age")
+
+        assert "## Error" in result


### PR DESCRIPTION
## Summary

- Implement all 18 MCP read tools across 7 entity modules: accounts (2), campaigns (2), ad sets (2), ads (2), insights (5), creatives (2), audiences (2)
- Add shared tool infrastructure: `get_client(ctx)` helper, `register(mcp)` pattern, `_insights_helpers.py` for date preset resolution and period comparison
- Add `format_insights_comparison()` and `format_performance_comparison()` formatters
- Wire all tool modules into `server.py` registration
- Add mypy override for MCP `Context` generic type in tools module
- 72 new tests (154 total), all passing with mypy/ruff/black clean

Closes #8, Closes #9, Closes #10, Closes #11, Closes #12, Closes #13, Closes #14, Closes #15, Closes #16, Closes #17, Closes #18, Closes #19, Closes #20, Closes #21, Closes #22, Closes #23, Closes #24, Closes #25

## Test plan

- [x] `poetry run pytest` — 154 tests pass
- [x] `poetry run mypy src/` — no type errors
- [x] `poetry run ruff check src/ tests/` — no lint issues
- [x] `poetry run black --check src/ tests/` — formatting clean