### PR TITLE
feat: add MCP tool annotations for read/write permission hinting

### DIFF
--- a/src/meta_ads_mcp/tools/__init__.py
+++ b/src/meta_ads_mcp/tools/__init__.py
@@ -1,8 +1,16 @@
 """MCP tool modules organized by Meta Ads entity type."""
 
 from mcp.server.fastmcp import Context
+from mcp.types import ToolAnnotations
 
 from meta_ads_mcp.client import MetaAdsClient
+
+# Shared tool annotations for permission hinting.
+# Clients use these to auto-approve read-only tools
+# while prompting for confirmation on write operations.
+READ_ANNOTATIONS = ToolAnnotations(readOnlyHint=True, destructiveHint=False)
+WRITE_ANNOTATIONS = ToolAnnotations(readOnlyHint=False, destructiveHint=False)
+DESTRUCTIVE_ANNOTATIONS = ToolAnnotations(readOnlyHint=False, destructiveHint=True)
 
 
 def get_client(ctx: Context) -> MetaAdsClient:

--- a/src/meta_ads_mcp/tools/accounts.py
+++ b/src/meta_ads_mcp/tools/accounts.py
@@ -5,7 +5,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from meta_ads_mcp.client import MetaAdsError
 from meta_ads_mcp.formatting import format_account, format_account_list, format_error
 from meta_ads_mcp.models import AdAccountModel
-from meta_ads_mcp.tools import get_client
+from meta_ads_mcp.tools import READ_ANNOTATIONS, get_client
 
 
 async def get_ad_accounts(ctx: Context) -> str:
@@ -46,5 +46,5 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool()(get_ad_accounts)
-    mcp.tool()(get_account_info)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_ad_accounts)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_account_info)

--- a/src/meta_ads_mcp/tools/ads.py
+++ b/src/meta_ads_mcp/tools/ads.py
@@ -14,7 +14,12 @@ from meta_ads_mcp.formatting import (
     format_write_result,
 )
 from meta_ads_mcp.models import AdDiagnosticsModel, AdModel
-from meta_ads_mcp.tools import get_client
+from meta_ads_mcp.tools import (
+    DESTRUCTIVE_ANNOTATIONS,
+    READ_ANNOTATIONS,
+    WRITE_ANNOTATIONS,
+    get_client,
+)
 from meta_ads_mcp.tools._write_helpers import (
     fetch_and_update,
     format_write_error,
@@ -186,8 +191,8 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool()(list_ads)
-    mcp.tool()(get_ad)
-    mcp.tool()(create_ad)
-    mcp.tool()(update_ad_status)
-    mcp.tool()(get_ad_diagnostics)
+    mcp.tool(annotations=READ_ANNOTATIONS)(list_ads)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_ad)
+    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_ad)
+    mcp.tool(annotations=DESTRUCTIVE_ANNOTATIONS)(update_ad_status)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_ad_diagnostics)

--- a/src/meta_ads_mcp/tools/adsets.py
+++ b/src/meta_ads_mcp/tools/adsets.py
@@ -15,7 +15,12 @@ from meta_ads_mcp.formatting import (
     format_write_result,
 )
 from meta_ads_mcp.models import AdSetDiagnosticsModel, AdSetModel
-from meta_ads_mcp.tools import get_client
+from meta_ads_mcp.tools import (
+    DESTRUCTIVE_ANNOTATIONS,
+    READ_ANNOTATIONS,
+    WRITE_ANNOTATIONS,
+    get_client,
+)
 from meta_ads_mcp.tools._write_helpers import (
     cents_display,
     dollars_to_cents,
@@ -351,8 +356,8 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool()(list_ad_sets)
-    mcp.tool()(get_ad_set)
-    mcp.tool()(create_ad_set)
-    mcp.tool()(update_ad_set)
-    mcp.tool()(get_ad_set_diagnostics)
+    mcp.tool(annotations=READ_ANNOTATIONS)(list_ad_sets)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_ad_set)
+    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_ad_set)
+    mcp.tool(annotations=DESTRUCTIVE_ANNOTATIONS)(update_ad_set)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_ad_set_diagnostics)

--- a/src/meta_ads_mcp/tools/audiences.py
+++ b/src/meta_ads_mcp/tools/audiences.py
@@ -12,7 +12,7 @@ from meta_ads_mcp.formatting import (
     format_write_result,
 )
 from meta_ads_mcp.models import CustomAudienceModel
-from meta_ads_mcp.tools import get_client
+from meta_ads_mcp.tools import READ_ANNOTATIONS, WRITE_ANNOTATIONS, get_client
 from meta_ads_mcp.tools._write_helpers import format_write_error, parse_json_param
 
 
@@ -182,7 +182,7 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool()(list_audiences)
-    mcp.tool()(get_audience)
-    mcp.tool()(create_custom_audience)
-    mcp.tool()(create_lookalike_audience)
+    mcp.tool(annotations=READ_ANNOTATIONS)(list_audiences)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_audience)
+    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_custom_audience)
+    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_lookalike_audience)

--- a/src/meta_ads_mcp/tools/campaigns.py
+++ b/src/meta_ads_mcp/tools/campaigns.py
@@ -14,7 +14,12 @@ from meta_ads_mcp.formatting import (
     format_write_result,
 )
 from meta_ads_mcp.models import CampaignDiagnosticsModel, CampaignModel
-from meta_ads_mcp.tools import get_client
+from meta_ads_mcp.tools import (
+    DESTRUCTIVE_ANNOTATIONS,
+    READ_ANNOTATIONS,
+    WRITE_ANNOTATIONS,
+    get_client,
+)
 from meta_ads_mcp.tools._write_helpers import (
     cents_display,
     dollars_to_cents,
@@ -319,8 +324,8 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool()(list_campaigns)
-    mcp.tool()(get_campaign)
-    mcp.tool()(create_campaign)
-    mcp.tool()(update_campaign)
-    mcp.tool()(get_campaign_diagnostics)
+    mcp.tool(annotations=READ_ANNOTATIONS)(list_campaigns)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_campaign)
+    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_campaign)
+    mcp.tool(annotations=DESTRUCTIVE_ANNOTATIONS)(update_campaign)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_campaign_diagnostics)

--- a/src/meta_ads_mcp/tools/creatives.py
+++ b/src/meta_ads_mcp/tools/creatives.py
@@ -13,7 +13,12 @@ from meta_ads_mcp.formatting import (
     format_write_result,
 )
 from meta_ads_mcp.models import AdCreativeModel
-from meta_ads_mcp.tools import get_client
+from meta_ads_mcp.tools import (
+    DESTRUCTIVE_ANNOTATIONS,
+    READ_ANNOTATIONS,
+    WRITE_ANNOTATIONS,
+    get_client,
+)
 from meta_ads_mcp.tools._write_helpers import (
     fetch_and_update,
     format_write_error,
@@ -206,7 +211,7 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool()(list_creatives)
-    mcp.tool()(get_creative)
-    mcp.tool()(create_ad_creative)
-    mcp.tool()(update_ad_creative)
+    mcp.tool(annotations=READ_ANNOTATIONS)(list_creatives)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_creative)
+    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_ad_creative)
+    mcp.tool(annotations=DESTRUCTIVE_ANNOTATIONS)(update_ad_creative)

--- a/src/meta_ads_mcp/tools/insights.py
+++ b/src/meta_ads_mcp/tools/insights.py
@@ -10,7 +10,7 @@ from meta_ads_mcp.formatting import (
     format_performance_comparison,
 )
 from meta_ads_mcp.models import InsightRow
-from meta_ads_mcp.tools import get_client
+from meta_ads_mcp.tools import READ_ANNOTATIONS, get_client
 from meta_ads_mcp.tools._insights_helpers import (
     VALID_BREAKDOWNS,
     get_previous_range,
@@ -277,8 +277,8 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool()(get_insights)
-    mcp.tool()(get_account_insights)
-    mcp.tool()(get_campaign_insights)
-    mcp.tool()(compare_performance)
-    mcp.tool()(get_breakdown_report)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_insights)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_account_insights)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_campaign_insights)
+    mcp.tool(annotations=READ_ANNOTATIONS)(compare_performance)
+    mcp.tool(annotations=READ_ANNOTATIONS)(get_breakdown_report)


### PR DESCRIPTION
## Summary

- Adds MCP `ToolAnnotations` to all 30 tools so clients can auto-approve read-only operations while prompting for confirmation on write operations
- Defines three shared annotation constants in `tools/__init__.py`: `READ_ANNOTATIONS`, `WRITE_ANNOTATIONS`, `DESTRUCTIVE_ANNOTATIONS`
- 20 read tools (`get_*`, `list_*`, `compare_*`) marked `readOnlyHint=True` — auto-approved by clients
- 6 create tools marked `readOnlyHint=False, destructiveHint=False` — requires approval (additive)
- 4 update tools marked `readOnlyHint=False, destructiveHint=True` — requires approval (modifies existing)

## Test plan

- [x] All 403 tests pass
- [x] mypy clean (no type errors)
- [x] ruff clean (no lint errors)
- [ ] Verify in Claude Desktop that read tools auto-approve and write tools prompt
- [ ] Verify in MCP Inspector that annotations appear in tool definitions