### PR TITLE
feat: enhance MCP tool annotations with 4-category permission model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__meta-ads__get_*",
+      "mcp__meta-ads__list_*",
+      "mcp__meta-ads__compare_performance"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -137,7 +137,57 @@ Add to your project's `.mcp.json`:
 }
 ```
 
-## Available Tools (35)
+### Permissions
+
+All tools include [MCP tool annotations](https://modelcontextprotocol.io/docs/concepts/tool-annotations) (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so clients can make informed permission decisions. However, Claude Code requires explicit allow rules — annotations alone don't auto-approve tools.
+
+**Within this project:** The project-level `.claude/settings.json` auto-allows read-only tools (`get_*`, `list_*`, `compare_performance`). Write tools require approval on each use.
+
+**From other projects:** Project-level permissions don't apply. To allow all tools globally, add to `~/.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__meta-ads__*"
+    ]
+  }
+}
+```
+
+Or for read-only tools only:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__meta-ads__get_*",
+      "mcp__meta-ads__list_*",
+      "mcp__meta-ads__compare_performance"
+    ]
+  }
+}
+```
+
+### Security Considerations
+
+This MCP server **cannot** modify account access, user permissions, login credentials, billing, or payment methods. There are no tools for account administration — a compromised server cannot lock anyone out of their account.
+
+**Worst-case impact if credentials are compromised:**
+
+| Risk | Details |
+|------|---------|
+| **Financial** | Creating campaigns/budgets could spend money once activated |
+| **Disruption** | Pausing or archiving campaigns, ad sets, or ads |
+| **Data exposure** | Reading account performance, targeting details, and audience information |
+
+Safety guards:
+- All new campaigns, ad sets, and ads default to **PAUSED** status
+- Write tools accept `dry_run=True` to validate without executing
+- No delete operations — use archive (`ARCHIVED` status) instead
+- Budget changes show before/after comparison in output
+
+## Available Tools (30)
 
 ### Accounts (2)
 | Tool | Description |

--- a/src/meta_ads_mcp/tools/__init__.py
+++ b/src/meta_ads_mcp/tools/__init__.py
@@ -5,12 +5,35 @@ from mcp.types import ToolAnnotations
 
 from meta_ads_mcp.client import MetaAdsClient
 
-# Shared tool annotations for permission hinting.
-# Clients use these to auto-approve read-only tools
-# while prompting for confirmation on write operations.
-READ_ANNOTATIONS = ToolAnnotations(readOnlyHint=True, destructiveHint=False)
-WRITE_ANNOTATIONS = ToolAnnotations(readOnlyHint=False, destructiveHint=False)
-DESTRUCTIVE_ANNOTATIONS = ToolAnnotations(readOnlyHint=False, destructiveHint=True)
+# --- Read-only tools (20) — query the Meta Ads API but never mutate ---
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    openWorldHint=True,
+)
+
+# --- Create tools (6) — create new resources; NOT idempotent ---
+CREATE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=True,
+)
+
+# --- Update tools (3) — modify existing resources; idempotent ---
+UPDATE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+
+# --- Destructive tools (1) — change status (pause/archive); idempotent ---
+DESTRUCTIVE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=True,
+    openWorldHint=True,
+)
 
 
 def get_client(ctx: Context) -> MetaAdsClient:

--- a/src/meta_ads_mcp/tools/accounts.py
+++ b/src/meta_ads_mcp/tools/accounts.py
@@ -5,7 +5,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from meta_ads_mcp.client import MetaAdsError
 from meta_ads_mcp.formatting import format_account, format_account_list, format_error
 from meta_ads_mcp.models import AdAccountModel
-from meta_ads_mcp.tools import READ_ANNOTATIONS, get_client
+from meta_ads_mcp.tools import READ_ONLY, get_client
 
 
 async def get_ad_accounts(ctx: Context) -> str:
@@ -46,5 +46,5 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_ad_accounts)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_account_info)
+    mcp.tool(annotations=READ_ONLY)(get_ad_accounts)
+    mcp.tool(annotations=READ_ONLY)(get_account_info)

--- a/src/meta_ads_mcp/tools/ads.py
+++ b/src/meta_ads_mcp/tools/ads.py
@@ -15,9 +15,9 @@ from meta_ads_mcp.formatting import (
 )
 from meta_ads_mcp.models import AdDiagnosticsModel, AdModel
 from meta_ads_mcp.tools import (
-    DESTRUCTIVE_ANNOTATIONS,
-    READ_ANNOTATIONS,
-    WRITE_ANNOTATIONS,
+    CREATE,
+    DESTRUCTIVE,
+    READ_ONLY,
     get_client,
 )
 from meta_ads_mcp.tools._write_helpers import (
@@ -191,8 +191,8 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool(annotations=READ_ANNOTATIONS)(list_ads)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_ad)
-    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_ad)
-    mcp.tool(annotations=DESTRUCTIVE_ANNOTATIONS)(update_ad_status)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_ad_diagnostics)
+    mcp.tool(annotations=READ_ONLY)(list_ads)
+    mcp.tool(annotations=READ_ONLY)(get_ad)
+    mcp.tool(annotations=CREATE)(create_ad)
+    mcp.tool(annotations=DESTRUCTIVE)(update_ad_status)
+    mcp.tool(annotations=READ_ONLY)(get_ad_diagnostics)

--- a/src/meta_ads_mcp/tools/adsets.py
+++ b/src/meta_ads_mcp/tools/adsets.py
@@ -16,9 +16,9 @@ from meta_ads_mcp.formatting import (
 )
 from meta_ads_mcp.models import AdSetDiagnosticsModel, AdSetModel
 from meta_ads_mcp.tools import (
-    DESTRUCTIVE_ANNOTATIONS,
-    READ_ANNOTATIONS,
-    WRITE_ANNOTATIONS,
+    CREATE,
+    READ_ONLY,
+    UPDATE,
     get_client,
 )
 from meta_ads_mcp.tools._write_helpers import (
@@ -356,8 +356,8 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool(annotations=READ_ANNOTATIONS)(list_ad_sets)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_ad_set)
-    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_ad_set)
-    mcp.tool(annotations=DESTRUCTIVE_ANNOTATIONS)(update_ad_set)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_ad_set_diagnostics)
+    mcp.tool(annotations=READ_ONLY)(list_ad_sets)
+    mcp.tool(annotations=READ_ONLY)(get_ad_set)
+    mcp.tool(annotations=CREATE)(create_ad_set)
+    mcp.tool(annotations=UPDATE)(update_ad_set)
+    mcp.tool(annotations=READ_ONLY)(get_ad_set_diagnostics)

--- a/src/meta_ads_mcp/tools/audiences.py
+++ b/src/meta_ads_mcp/tools/audiences.py
@@ -12,7 +12,7 @@ from meta_ads_mcp.formatting import (
     format_write_result,
 )
 from meta_ads_mcp.models import CustomAudienceModel
-from meta_ads_mcp.tools import READ_ANNOTATIONS, WRITE_ANNOTATIONS, get_client
+from meta_ads_mcp.tools import CREATE, READ_ONLY, get_client
 from meta_ads_mcp.tools._write_helpers import format_write_error, parse_json_param
 
 
@@ -182,7 +182,7 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool(annotations=READ_ANNOTATIONS)(list_audiences)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_audience)
-    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_custom_audience)
-    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_lookalike_audience)
+    mcp.tool(annotations=READ_ONLY)(list_audiences)
+    mcp.tool(annotations=READ_ONLY)(get_audience)
+    mcp.tool(annotations=CREATE)(create_custom_audience)
+    mcp.tool(annotations=CREATE)(create_lookalike_audience)

--- a/src/meta_ads_mcp/tools/campaigns.py
+++ b/src/meta_ads_mcp/tools/campaigns.py
@@ -15,9 +15,9 @@ from meta_ads_mcp.formatting import (
 )
 from meta_ads_mcp.models import CampaignDiagnosticsModel, CampaignModel
 from meta_ads_mcp.tools import (
-    DESTRUCTIVE_ANNOTATIONS,
-    READ_ANNOTATIONS,
-    WRITE_ANNOTATIONS,
+    CREATE,
+    READ_ONLY,
+    UPDATE,
     get_client,
 )
 from meta_ads_mcp.tools._write_helpers import (
@@ -324,8 +324,8 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool(annotations=READ_ANNOTATIONS)(list_campaigns)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_campaign)
-    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_campaign)
-    mcp.tool(annotations=DESTRUCTIVE_ANNOTATIONS)(update_campaign)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_campaign_diagnostics)
+    mcp.tool(annotations=READ_ONLY)(list_campaigns)
+    mcp.tool(annotations=READ_ONLY)(get_campaign)
+    mcp.tool(annotations=CREATE)(create_campaign)
+    mcp.tool(annotations=UPDATE)(update_campaign)
+    mcp.tool(annotations=READ_ONLY)(get_campaign_diagnostics)

--- a/src/meta_ads_mcp/tools/creatives.py
+++ b/src/meta_ads_mcp/tools/creatives.py
@@ -14,9 +14,9 @@ from meta_ads_mcp.formatting import (
 )
 from meta_ads_mcp.models import AdCreativeModel
 from meta_ads_mcp.tools import (
-    DESTRUCTIVE_ANNOTATIONS,
-    READ_ANNOTATIONS,
-    WRITE_ANNOTATIONS,
+    CREATE,
+    READ_ONLY,
+    UPDATE,
     get_client,
 )
 from meta_ads_mcp.tools._write_helpers import (
@@ -211,7 +211,7 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool(annotations=READ_ANNOTATIONS)(list_creatives)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_creative)
-    mcp.tool(annotations=WRITE_ANNOTATIONS)(create_ad_creative)
-    mcp.tool(annotations=DESTRUCTIVE_ANNOTATIONS)(update_ad_creative)
+    mcp.tool(annotations=READ_ONLY)(list_creatives)
+    mcp.tool(annotations=READ_ONLY)(get_creative)
+    mcp.tool(annotations=CREATE)(create_ad_creative)
+    mcp.tool(annotations=UPDATE)(update_ad_creative)

--- a/src/meta_ads_mcp/tools/insights.py
+++ b/src/meta_ads_mcp/tools/insights.py
@@ -10,7 +10,7 @@ from meta_ads_mcp.formatting import (
     format_performance_comparison,
 )
 from meta_ads_mcp.models import InsightRow
-from meta_ads_mcp.tools import READ_ANNOTATIONS, get_client
+from meta_ads_mcp.tools import READ_ONLY, get_client
 from meta_ads_mcp.tools._insights_helpers import (
     VALID_BREAKDOWNS,
     get_previous_range,
@@ -277,8 +277,8 @@ def register(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance.
     """
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_insights)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_account_insights)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_campaign_insights)
-    mcp.tool(annotations=READ_ANNOTATIONS)(compare_performance)
-    mcp.tool(annotations=READ_ANNOTATIONS)(get_breakdown_report)
+    mcp.tool(annotations=READ_ONLY)(get_insights)
+    mcp.tool(annotations=READ_ONLY)(get_account_insights)
+    mcp.tool(annotations=READ_ONLY)(get_campaign_insights)
+    mcp.tool(annotations=READ_ONLY)(compare_performance)
+    mcp.tool(annotations=READ_ONLY)(get_breakdown_report)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,173 @@
+"""Tests that every registered MCP tool has correct ToolAnnotations."""
+
+from __future__ import annotations
+
+import pytest
+
+from meta_ads_mcp.server import mcp
+from meta_ads_mcp.tools import CREATE, DESTRUCTIVE, READ_ONLY, UPDATE
+
+# ── Expected annotation mapping (tool name → annotation constant) ──────────
+
+EXPECTED: dict[str, object] = {
+    # accounts.py
+    "get_ad_accounts": READ_ONLY,
+    "get_account_info": READ_ONLY,
+    # campaigns.py
+    "list_campaigns": READ_ONLY,
+    "get_campaign": READ_ONLY,
+    "create_campaign": CREATE,
+    "update_campaign": UPDATE,
+    "get_campaign_diagnostics": READ_ONLY,
+    # adsets.py
+    "list_ad_sets": READ_ONLY,
+    "get_ad_set": READ_ONLY,
+    "create_ad_set": CREATE,
+    "update_ad_set": UPDATE,
+    "get_ad_set_diagnostics": READ_ONLY,
+    # ads.py
+    "list_ads": READ_ONLY,
+    "get_ad": READ_ONLY,
+    "create_ad": CREATE,
+    "update_ad_status": DESTRUCTIVE,
+    "get_ad_diagnostics": READ_ONLY,
+    # insights.py
+    "get_insights": READ_ONLY,
+    "get_account_insights": READ_ONLY,
+    "get_campaign_insights": READ_ONLY,
+    "compare_performance": READ_ONLY,
+    "get_breakdown_report": READ_ONLY,
+    # creatives.py
+    "list_creatives": READ_ONLY,
+    "get_creative": READ_ONLY,
+    "create_ad_creative": CREATE,
+    "update_ad_creative": UPDATE,
+    # audiences.py
+    "list_audiences": READ_ONLY,
+    "get_audience": READ_ONLY,
+    "create_custom_audience": CREATE,
+    "create_lookalike_audience": CREATE,
+}
+
+
+def _get_tools() -> dict:
+    """Return the registered tool map from FastMCP."""
+    return mcp._tool_manager._tools
+
+
+# ── Structural tests ───────────────────────────────────────────────────────
+
+
+class TestAllToolsAnnotated:
+    """Ensure every registered tool has annotations and is covered by the mapping."""
+
+    def test_every_tool_has_annotations(self):
+        for name, tool in _get_tools().items():
+            assert tool.annotations is not None, f"Tool '{name}' is missing annotations"
+
+    def test_no_unmapped_tools(self):
+        registered = set(_get_tools().keys())
+        mapped = set(EXPECTED.keys())
+        unmapped = registered - mapped
+        assert not unmapped, f"Tools registered but not in EXPECTED mapping: {unmapped}"
+
+    def test_no_stale_mapping_entries(self):
+        registered = set(_get_tools().keys())
+        mapped = set(EXPECTED.keys())
+        stale = mapped - registered
+        assert not stale, f"EXPECTED has entries for non-existent tools: {stale}"
+
+    def test_tool_count(self):
+        assert len(_get_tools()) == 30, f"Expected 30 tools, found {len(_get_tools())}"
+
+
+# ── Per-tool annotation correctness ───────────────────────────────────────
+
+
+@pytest.mark.parametrize("tool_name,expected_ann", list(EXPECTED.items()))
+def test_tool_annotation_matches(tool_name, expected_ann):
+    tools = _get_tools()
+    assert tool_name in tools, f"Tool '{tool_name}' not registered"
+    actual = tools[tool_name].annotations
+    assert actual == expected_ann, (
+        f"Tool '{tool_name}' annotation mismatch:\n"
+        f"  expected: {expected_ann}\n"
+        f"  actual:   {actual}"
+    )
+
+
+# ── Category-level invariant tests ────────────────────────────────────────
+
+
+class TestReadOnlyTools:
+    """Read-only tools must have readOnlyHint=True."""
+
+    @pytest.fixture
+    def read_tools(self):
+        return {n: _get_tools()[n] for n, a in EXPECTED.items() if a is READ_ONLY}
+
+    def test_read_only_hint(self, read_tools):
+        for name, tool in read_tools.items():
+            assert (
+                tool.annotations.readOnlyHint is True
+            ), f"'{name}' should be readOnlyHint=True"
+
+
+class TestCreateTools:
+    """Create tools must not be destructive and must not be idempotent."""
+
+    @pytest.fixture
+    def create_tools(self):
+        return {n: _get_tools()[n] for n, a in EXPECTED.items() if a is CREATE}
+
+    def test_not_destructive(self, create_tools):
+        for name, tool in create_tools.items():
+            assert (
+                tool.annotations.destructiveHint is False
+            ), f"'{name}' should be destructiveHint=False"
+
+    def test_not_idempotent(self, create_tools):
+        for name, tool in create_tools.items():
+            assert (
+                tool.annotations.idempotentHint is False
+            ), f"'{name}' should be idempotentHint=False"
+
+
+class TestUpdateTools:
+    """Update tools must be idempotent and not destructive."""
+
+    @pytest.fixture
+    def update_tools(self):
+        return {n: _get_tools()[n] for n, a in EXPECTED.items() if a is UPDATE}
+
+    def test_not_destructive(self, update_tools):
+        for name, tool in update_tools.items():
+            assert (
+                tool.annotations.destructiveHint is False
+            ), f"'{name}' should be destructiveHint=False"
+
+    def test_idempotent(self, update_tools):
+        for name, tool in update_tools.items():
+            assert (
+                tool.annotations.idempotentHint is True
+            ), f"'{name}' should be idempotentHint=True"
+
+
+class TestDestructiveTools:
+    """Destructive tools must have destructiveHint=True."""
+
+    @pytest.fixture
+    def destructive_tools(self):
+        return {n: _get_tools()[n] for n, a in EXPECTED.items() if a is DESTRUCTIVE}
+
+    def test_destructive_hint(self, destructive_tools):
+        for name, tool in destructive_tools.items():
+            assert (
+                tool.annotations.destructiveHint is True
+            ), f"'{name}' should be destructiveHint=True"
+
+    def test_idempotent(self, destructive_tools):
+        for name, tool in destructive_tools.items():
+            assert (
+                tool.annotations.idempotentHint is True
+            ), f"'{name}' should be idempotentHint=True"


### PR DESCRIPTION
## Summary

- Replace 3 coarse annotation constants (`READ_ANNOTATIONS`, `WRITE_ANNOTATIONS`, `DESTRUCTIVE_ANNOTATIONS`) with 4 granular categories (`READ_ONLY`, `CREATE`, `UPDATE`, `DESTRUCTIVE`) that explicitly set all MCP ToolAnnotation fields (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
- Add project-level `.claude/settings.json` to auto-allow read-only tools in Claude Code
- Add 41 annotation tests covering structural integrity, per-tool correctness, and category invariants
- Add Permissions and Security Considerations sections to README
- Fix tool count in README (35 → 30)

### Annotation categories (30 tools)

| Category | Count | Key properties |
|----------|-------|----------------|
| **READ_ONLY** | 20 | readOnly, not destructive |
| **CREATE** | 6 | not readOnly, not destructive, not idempotent |
| **UPDATE** | 3 | not readOnly, not destructive, idempotent |
| **DESTRUCTIVE** | 1 | not readOnly, destructive, idempotent |

### Key reclassifications
- `update_campaign`, `update_ad_set`, `update_ad_creative`: DESTRUCTIVE → UPDATE (field modifications, not status changes)
- `update_ad_status`: remains DESTRUCTIVE (can pause/archive, affecting delivery)
- All create tools: WRITE → CREATE (non-idempotent)

## Test plan
- [x] `uv run pytest tests/test_annotations.py -v` — 41 annotation tests pass
- [x] `uv run pytest` — 444 tests pass (no regressions)
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run black --check src/ tests/` — clean