### PR TITLE
feat: add image and video asset upload tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Meta Ads MCP server — a locally-hosted MCP server wrapping the Meta (Facebook)
 
 ## Architecture Rules
 
-- Tools live in `src/meta_ads_mcp/tools/` organized by entity: `accounts.py`, `campaigns.py`, `adsets.py`, `ads.py`, `insights.py`, `creatives.py`, `audiences.py`
+- Tools live in `src/meta_ads_mcp/tools/` organized by entity: `accounts.py`, `campaigns.py`, `adsets.py`, `ads.py`, `insights.py`, `creatives.py`, `audiences.py`, `assets.py`
 - Tools return **formatted markdown strings**, never raw JSON or SDK objects
 - `MetaAdsClient` in `client.py` is the single API interface — tools never call the facebook-business SDK directly
 - Use `asyncio.to_thread()` to wrap synchronous facebook-business SDK calls for async compatibility

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -25,10 +25,15 @@ A locally-hosted MCP server wrapping the Meta (Facebook) Ads API for agency/mult
 - Creative create/update tools with dry_run support
 - Advantage+ campaign support, frequency capping, attribution spec
 - Audience creation (custom and lookalike)
-- 35 total MCP tools, 363 tests passing
+- 30 total MCP tools, 363 tests passing
 
-### v4 — Advanced
-- Creative asset upload (image/video)
+### v4 — Asset Upload (Complete)
+- Image upload from local file, returns hash for use in creatives
+- Video upload from local file or URL (Meta fetches directly)
+- Image and video listing and detail views
+- 36 total MCP tools, 506 tests passing
+
+### v5 — Advanced
 - Bulk operations
 - Automated reporting and trend analysis
 
@@ -50,7 +55,8 @@ src/meta_ads_mcp/
     ├── ads.py       # Ad CRUD
     ├── insights.py  # Performance reporting and analytics
     ├── creatives.py # Creative management
-    └── audiences.py # Audience management
+    ├── audiences.py # Audience management
+    └── assets.py    # Image and video asset upload/listing
 ```
 
 ## Tech Stack
@@ -93,7 +99,7 @@ Agency use case requires managing multiple client ad accounts. Every tool accept
 - Instagram-specific APIs (beyond what's exposed through Ads API)
 - SSE transport (stdio only for local hosting)
 
-## Tools (35 across 7 categories)
+## Tools (36 across 8 categories)
 
 ### Accounts (2)
 | Tool | Description |
@@ -152,3 +158,13 @@ Agency use case requires managing multiple client ad accounts. Every tool accept
 | `get_audience` | Get audience details including size and status |
 | `create_custom_audience` | Create website/app/customer file audience |
 | `create_lookalike_audience` | Create lookalike from source audience |
+
+### Assets (6)
+| Tool | Description |
+|---|---|
+| `upload_ad_image` | Upload an image file, returns hash for creatives |
+| `upload_ad_video` | Upload a video from file or URL |
+| `list_ad_images` | List ad images for an account |
+| `get_ad_image` | Get image details by hash |
+| `list_ad_videos` | List ad videos for an account |
+| `get_ad_video` | Get video details by ID |

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Safety guards:
 - No delete operations — use archive (`ARCHIVED` status) instead
 - Budget changes show before/after comparison in output
 
-## Available Tools (30)
+## Available Tools (36)
 
 ### Accounts (2)
 | Tool | Description |
@@ -246,6 +246,16 @@ Safety guards:
 | `get_audience` | Get audience details including size and status |
 | `create_custom_audience` | Create website, customer list, or app audiences |
 | `create_lookalike_audience` | Create a lookalike from an existing audience |
+
+### Assets (6)
+| Tool | Description |
+|---|---|
+| `upload_ad_image` | Upload an image file, returns hash for use in creatives |
+| `upload_ad_video` | Upload a video from local file or URL |
+| `list_ad_images` | List ad images for an account |
+| `get_ad_image` | Get image details by hash |
+| `list_ad_videos` | List ad videos for an account |
+| `get_ad_video` | Get video details by ID |
 
 ## Safety Patterns
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -103,10 +103,19 @@ GitHub Project: [Meta Ads MCP](https://github.com/users/tomleelong/projects/2)
 - [x] #36 End-to-end testing (Claude Desktop config, MCP Inspector)
 - [x] #37 README finalization with usage examples
 
+## Phase 6: Asset Upload
+
+- [x] #65 `AdImageModel` and `AdVideoModel` Pydantic models
+- [x] #66 Client methods for image/video operations
+- [x] #67 Formatters for image/video display
+- [x] #68 Asset upload and listing tools (6 tools)
+- [x] #69 Unit tests for asset tools
+- [x] #70 Update project docs for Phase 6
+
 ## Backlog / Future
 
 - [x] #40 Persistent Meta access token — system user token (non-expiring)
-- [ ] Creative upload tools (image/video asset upload)
+- [x] Creative upload tools (image/video asset upload) — completed in Phase 6
 - [ ] Bulk operations (batch status changes, batch budget updates)
 - [ ] Trend analysis / ROAS tracking tools
 - [ ] SSE transport for remote hosting

--- a/docs/phase6-asset-upload.md
+++ b/docs/phase6-asset-upload.md
@@ -1,0 +1,147 @@
+# Plan: Creative Asset Upload (Image & Video) — Phase 6
+
+> **First step after approval:** Save this plan as `docs/phase6-asset-upload.md` in the project.
+
+## Context
+
+The user tried to upload an ad image and discovered the MCP has no asset upload capability. The `create_ad_creative` tool accepts `image_hash` and `image_url` parameters, but there's no way to upload an image to get a hash. The Meta Marketing API and the facebook-business SDK (v25.0) both fully support image and video upload via `AdImage` and `AdVideo` classes. This is listed under v4 Advanced in PROJECT.md.
+
+This adds 6 new tools (41 total), a new `tools/assets.py` module, and completes the "Creative asset upload (image/video)" backlog item.
+
+---
+
+## GitHub Issues (#65–#70)
+
+### #65 — `AdImageModel` and `AdVideoModel` Pydantic models
+**Labels:** `phase:asset-upload`, `area:assets`
+
+Add to `src/meta_ads_mcp/models.py`:
+
+**`AdImageModel`:** `id`, `hash`, `name`, `account_id`, `url`, `url_128`, `width`, `height`, `original_width`, `original_height`, `status`, `permalink_url`, `created_time`, `updated_time` + `dimensions_display` property
+
+**`AdVideoModel`:** `id`, `name`, `title`, `description`, `length` (float), `source`, `created_time`, `updated_time` + `duration_display` property
+
+Both use `ConfigDict(extra="ignore")`, all fields with defaults.
+
+### #66 — Client methods for image/video operations
+**Labels:** `phase:asset-upload`, `area:core`
+
+Add to `src/meta_ads_mcp/client.py` (6 methods):
+
+| Method | SDK Usage | Notes |
+|---|---|---|
+| `upload_ad_image(file_path, name?, account_id?)` | `AdImage(parent_id=account_id)` + `remote_create()` with filename field | Validate file exists; returns dict with `hash` |
+| `upload_ad_video(file_path?, file_url?, name?, title?, description?, account_id?)` | `account.create_ad_video(params)` | Accept file path OR URL; SDK handles chunked upload |
+| `get_ad_images(account_id?, limit=50)` | `account.get_ad_images(fields, params)` | Standard list pattern with `islice` |
+| `get_ad_image(image_hash, account_id?)` | `account.get_ad_images(params={"hashes": [hash]})` | Lookup by hash (not composite ID) |
+| `get_ad_videos(account_id?, limit=50)` | `account.get_ad_videos(fields, params)` | Standard list pattern |
+| `get_ad_video(video_id)` | `AdVideo(id).api_get(fields)` | Standard get pattern |
+
+Import `AdImage` from `facebook_business.adobjects.adimage` and `AdVideo` from `facebook_business.adobjects.advideo`.
+
+**No `dry_run`** — Meta's upload endpoints don't support `validate_only`.
+
+**No video encoding polling** — `waitUntilEncodingReady()` blocks up to 10min. Return immediately with video ID; user can check status via `get_ad_video`.
+
+### #67 — Formatters for image/video display
+**Labels:** `phase:asset-upload`, `area:assets`
+
+Add to `src/meta_ads_mcp/formatting.py`:
+
+- `format_ad_image(AdImageModel)` — detail view, **hash prominently displayed** (it's the key output users need for `create_ad_creative`)
+- `format_ad_image_list(list[AdImageModel])` — table: Hash | Name | Dimensions | Status
+- `format_ad_video(AdVideoModel)` — detail view, **video ID prominently displayed**
+- `format_ad_video_list(list[AdVideoModel])` — table: ID | Name | Title | Duration
+
+### #68 — Asset upload and listing tools
+**Labels:** `phase:asset-upload`, `area:assets`
+
+**New file: `src/meta_ads_mcp/tools/assets.py`**
+
+| Tool | Annotation | Key params |
+|---|---|---|
+| `upload_ad_image` | `CREATE` | `file_path`, `name?`, `account_id?` |
+| `upload_ad_video` | `CREATE` | `file_path?`, `file_url?`, `name?`, `title?`, `description?`, `account_id?` |
+| `list_ad_images` | `READ_ONLY` | `account_id?`, `limit=50` |
+| `get_ad_image` | `READ_ONLY` | `image_hash`, `account_id?` |
+| `list_ad_videos` | `READ_ONLY` | `account_id?`, `limit=50` |
+| `get_ad_video` | `READ_ONLY` | `video_id` |
+
+Plus `register(mcp)` function.
+
+**Update `server.py`:** Add `from meta_ads_mcp.tools import assets` + `assets.register(mcp)`.
+
+**Upload tool output must include usage hint:** e.g., "Use this hash with `create_ad_creative`'s `image_hash` parameter"
+
+### #69 — Unit tests for asset tools
+**Labels:** `phase:asset-upload`, `area:assets`
+
+**New files:**
+- `tests/test_tools_assets.py` — tool function tests (success, error, params for all 6 tools)
+- `tests/test_client_assets.py` — client method tests (mock SDK objects)
+
+**Update existing:**
+- `tests/test_models.py` — AdImageModel/AdVideoModel defaults, properties, extra="ignore"
+- `tests/test_formatting.py` — format_ad_image/video, list formatters, empty lists
+- `tests/test_annotations.py` — verify annotations for 6 new tools
+
+### #70 — Update project docs and metadata
+**Labels:** `phase:asset-upload`, `area:core`
+
+- `PROJECT.md` — update tool count (35→41), add Assets category, add `assets.py` to architecture diagram, move asset upload from v4 to completed
+- `TASKS.md` — add Phase 6 section with issues #58–#63
+- `CLAUDE.md` — add `assets.py` to tools listing
+- `README.md` — add asset tools to tool table
+
+---
+
+## Implementation Order
+
+```
+#65 (models) → #66 (client) → #67 (formatters) → #68 (tools + registration) → #69 (tests) → #70 (docs)
+```
+
+Issues #65–#68 are tightly coupled — implement as a single PR. Tests (#69) can be a second PR or bundled together. Docs (#70) as final PR.
+
+**Recommended: 1–2 PRs total** to avoid merge overhead.
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|---|---|
+| `file_path` only for images (no base64) | MCP server runs locally with filesystem access; base64 is wasteful. Users with URLs can use `create_ad_creative`'s `image_url` directly |
+| `file_path` OR `file_url` for videos | Videos are large — `file_url` lets Meta fetch directly without local download |
+| `image_hash` as lookup key (not composite ID) | Hash is what upload returns and what `create_ad_creative` consumes — more natural workflow |
+| No `dry_run` for uploads | Meta API doesn't support `validate_only` on upload endpoints |
+| No encoding polling for video | Blocking 10min is unacceptable for MCP tool; return immediately, check via `get_ad_video` |
+| New `tools/assets.py` module | Assets span images and videos — distinct from creatives which are ad-level objects |
+
+---
+
+## Key Files to Modify
+
+| File | Change |
+|---|---|
+| `src/meta_ads_mcp/models.py` | Add `AdImageModel`, `AdVideoModel` |
+| `src/meta_ads_mcp/client.py` | Add 6 async methods, import `AdImage`/`AdVideo` |
+| `src/meta_ads_mcp/formatting.py` | Add 4 formatter functions |
+| `src/meta_ads_mcp/tools/assets.py` | **New** — 6 tools + `register()` |
+| `src/meta_ads_mcp/server.py` | Import + register assets module |
+| `tests/test_tools_assets.py` | **New** — tool tests |
+| `tests/test_client_assets.py` | **New** — client tests |
+| `tests/test_models.py` | Add model tests |
+| `tests/test_formatting.py` | Add formatter tests |
+| `tests/test_annotations.py` | Add annotation checks |
+
+---
+
+## Verification
+
+1. **Unit tests:** `uv run pytest` — all existing 390+ tests still pass, new tests pass
+2. **Type checking:** `uv run mypy src/` — clean
+3. **Linting:** `uv run ruff check src/` + `uv run black --check src/` — clean
+4. **MCP Inspector:** `npx @modelcontextprotocol/inspector uv run python -m meta_ads_mcp` — verify 6 new tools appear
+5. **Live test (manual):** Upload a test image via `upload_ad_image`, confirm hash returned, use hash in `create_ad_creative`
+6. **Live test (manual):** Upload a test video via `upload_ad_video` with `file_url`, confirm video ID returned

--- a/src/meta_ads_mcp/client.py
+++ b/src/meta_ads_mcp/client.py
@@ -1445,6 +1445,36 @@ class MetaAdsClient:
 
     # ── Asset (Image/Video) Methods ──────────────────────────────
 
+    _AD_IMAGE_FIELDS = [
+        AdImage.Field.id,
+        AdImage.Field.hash,
+        AdImage.Field.name,
+        AdImage.Field.account_id,
+        AdImage.Field.url,
+        AdImage.Field.url_128,
+        AdImage.Field.width,
+        AdImage.Field.height,
+        AdImage.Field.original_width,
+        AdImage.Field.original_height,
+        AdImage.Field.status,
+        AdImage.Field.permalink_url,
+        AdImage.Field.created_time,
+        AdImage.Field.updated_time,
+    ]
+
+    _AD_VIDEO_FIELDS = [
+        AdVideo.Field.id,
+        AdVideo.Field.name,
+        AdVideo.Field.title,
+        AdVideo.Field.description,
+        AdVideo.Field.length,
+        AdVideo.Field.source,
+        AdVideo.Field.picture,
+        AdVideo.Field.permalink_url,
+        AdVideo.Field.created_time,
+        AdVideo.Field.updated_time,
+    ]
+
     async def upload_ad_image(
         self,
         file_path: str,
@@ -1462,13 +1492,6 @@ class MetaAdsClient:
             Image data dictionary containing the image hash.
         """
         self._ensure_initialized()
-
-        import os
-
-        if not os.path.isfile(file_path):
-            raise MetaAdsError(
-                message=f"File not found: {file_path}",
-            )
 
         def _upload() -> dict[str, Any]:
             try:
@@ -1517,13 +1540,6 @@ class MetaAdsClient:
                 message="Either file_path or file_url must be provided.",
             )
 
-        import os
-
-        if file_path and not os.path.isfile(file_path):
-            raise MetaAdsError(
-                message=f"File not found: {file_path}",
-            )
-
         def _upload() -> dict[str, Any]:
             try:
                 account = self._get_account(account_id)
@@ -1567,22 +1583,7 @@ class MetaAdsClient:
             try:
                 account = self._get_account(account_id)
                 images = account.get_ad_images(
-                    fields=[
-                        AdImage.Field.id,
-                        AdImage.Field.hash,
-                        AdImage.Field.name,
-                        AdImage.Field.account_id,
-                        AdImage.Field.url,
-                        AdImage.Field.url_128,
-                        AdImage.Field.width,
-                        AdImage.Field.height,
-                        AdImage.Field.original_width,
-                        AdImage.Field.original_height,
-                        AdImage.Field.status,
-                        AdImage.Field.permalink_url,
-                        AdImage.Field.created_time,
-                        AdImage.Field.updated_time,
-                    ],
+                    fields=self._AD_IMAGE_FIELDS,
                     params={"limit": limit},
                 )
                 return [dict(img) for img in itertools.islice(images, limit)]
@@ -1613,30 +1614,15 @@ class MetaAdsClient:
             try:
                 account = self._get_account(account_id)
                 images = account.get_ad_images(
-                    fields=[
-                        AdImage.Field.id,
-                        AdImage.Field.hash,
-                        AdImage.Field.name,
-                        AdImage.Field.account_id,
-                        AdImage.Field.url,
-                        AdImage.Field.url_128,
-                        AdImage.Field.width,
-                        AdImage.Field.height,
-                        AdImage.Field.original_width,
-                        AdImage.Field.original_height,
-                        AdImage.Field.status,
-                        AdImage.Field.permalink_url,
-                        AdImage.Field.created_time,
-                        AdImage.Field.updated_time,
-                    ],
+                    fields=self._AD_IMAGE_FIELDS,
                     params={"hashes": [image_hash]},
                 )
-                results = list(images)
-                if not results:
+                first = next(iter(images), None)
+                if first is None:
                     raise MetaAdsError(
                         message=f"No image found with hash: {image_hash}",
                     )
-                return dict(results[0])
+                return dict(first)
             except FacebookRequestError as e:
                 raise self._handle_api_error(e) from e
             except (ConnectionError, TimeoutError, OSError) as e:
@@ -1664,18 +1650,7 @@ class MetaAdsClient:
             try:
                 account = self._get_account(account_id)
                 videos = account.get_ad_videos(
-                    fields=[
-                        AdVideo.Field.id,
-                        AdVideo.Field.name,
-                        AdVideo.Field.title,
-                        AdVideo.Field.description,
-                        AdVideo.Field.length,
-                        AdVideo.Field.source,
-                        AdVideo.Field.picture,
-                        AdVideo.Field.permalink_url,
-                        AdVideo.Field.created_time,
-                        AdVideo.Field.updated_time,
-                    ],
+                    fields=self._AD_VIDEO_FIELDS,
                     params={"limit": limit},
                 )
                 return [dict(v) for v in itertools.islice(videos, limit)]
@@ -1700,20 +1675,7 @@ class MetaAdsClient:
         def _fetch() -> dict[str, Any]:
             try:
                 video = AdVideo(video_id)
-                video.api_get(
-                    fields=[
-                        AdVideo.Field.id,
-                        AdVideo.Field.name,
-                        AdVideo.Field.title,
-                        AdVideo.Field.description,
-                        AdVideo.Field.length,
-                        AdVideo.Field.source,
-                        AdVideo.Field.picture,
-                        AdVideo.Field.permalink_url,
-                        AdVideo.Field.created_time,
-                        AdVideo.Field.updated_time,
-                    ]
-                )
+                video.api_get(fields=self._AD_VIDEO_FIELDS)
                 return dict(video)
             except FacebookRequestError as e:
                 raise self._handle_api_error(e) from e

--- a/src/meta_ads_mcp/client.py
+++ b/src/meta_ads_mcp/client.py
@@ -12,7 +12,9 @@ from typing import Any
 from facebook_business.adobjects.ad import Ad
 from facebook_business.adobjects.adaccount import AdAccount
 from facebook_business.adobjects.adcreative import AdCreative
+from facebook_business.adobjects.adimage import AdImage
 from facebook_business.adobjects.adset import AdSet
+from facebook_business.adobjects.advideo import AdVideo
 from facebook_business.adobjects.campaign import Campaign
 from facebook_business.adobjects.customaudience import CustomAudience
 from facebook_business.adobjects.user import User
@@ -1440,3 +1442,282 @@ class MetaAdsClient:
                 raise self._handle_api_error(e) from e
 
         return await asyncio.to_thread(_create)
+
+    # ── Asset (Image/Video) Methods ──────────────────────────────
+
+    async def upload_ad_image(
+        self,
+        file_path: str,
+        name: str | None = None,
+        account_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Upload an image to the ad account.
+
+        Args:
+            file_path: Local file path to the image.
+            name: Optional name for the image.
+            account_id: Ad account ID, or None for default.
+
+        Returns:
+            Image data dictionary containing the image hash.
+        """
+        self._ensure_initialized()
+
+        import os
+
+        if not os.path.isfile(file_path):
+            raise MetaAdsError(
+                message=f"File not found: {file_path}",
+            )
+
+        def _upload() -> dict[str, Any]:
+            try:
+                account = self._get_account(account_id)
+                image = AdImage(parent_id=account.get_id())
+                image[AdImage.Field.filename] = file_path
+                if name:
+                    image[AdImage.Field.name] = name
+                image.remote_create()
+                return dict(image)
+            except FacebookRequestError as e:
+                raise self._handle_api_error(e) from e
+            except (ConnectionError, TimeoutError, OSError) as e:
+                raise MetaAdsError(message=f"Network error: {e}") from e
+
+        return await asyncio.to_thread(_upload)
+
+    async def upload_ad_video(
+        self,
+        file_path: str | None = None,
+        file_url: str | None = None,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        account_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Upload a video to the ad account.
+
+        Accepts either a local file path or a URL that Meta will fetch.
+
+        Args:
+            file_path: Local file path to the video.
+            file_url: URL for Meta to fetch the video from.
+            name: Optional name for the video.
+            title: Optional title for the video.
+            description: Optional description for the video.
+            account_id: Ad account ID, or None for default.
+
+        Returns:
+            Video data dictionary containing the video ID.
+        """
+        self._ensure_initialized()
+
+        if not file_path and not file_url:
+            raise MetaAdsError(
+                message="Either file_path or file_url must be provided.",
+            )
+
+        import os
+
+        if file_path and not os.path.isfile(file_path):
+            raise MetaAdsError(
+                message=f"File not found: {file_path}",
+            )
+
+        def _upload() -> dict[str, Any]:
+            try:
+                account = self._get_account(account_id)
+                params: dict[str, Any] = {}
+                if name:
+                    params["name"] = name
+                if title:
+                    params["title"] = title
+                if description:
+                    params["description"] = description
+                if file_url:
+                    params["file_url"] = file_url
+                if file_path:
+                    params["filepath"] = file_path
+                result = account.create_ad_video(params=params)
+                return dict(result)
+            except FacebookRequestError as e:
+                raise self._handle_api_error(e) from e
+            except (ConnectionError, TimeoutError, OSError) as e:
+                raise MetaAdsError(message=f"Network error: {e}") from e
+
+        return await asyncio.to_thread(_upload)
+
+    async def get_ad_images(
+        self,
+        account_id: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List ad images for an account.
+
+        Args:
+            account_id: The ad account ID, or None for default.
+            limit: Maximum number of images to return.
+
+        Returns:
+            A list of image data dictionaries.
+        """
+        self._ensure_initialized()
+
+        def _fetch() -> list[dict[str, Any]]:
+            try:
+                account = self._get_account(account_id)
+                images = account.get_ad_images(
+                    fields=[
+                        AdImage.Field.id,
+                        AdImage.Field.hash,
+                        AdImage.Field.name,
+                        AdImage.Field.account_id,
+                        AdImage.Field.url,
+                        AdImage.Field.url_128,
+                        AdImage.Field.width,
+                        AdImage.Field.height,
+                        AdImage.Field.original_width,
+                        AdImage.Field.original_height,
+                        AdImage.Field.status,
+                        AdImage.Field.permalink_url,
+                        AdImage.Field.created_time,
+                        AdImage.Field.updated_time,
+                    ],
+                    params={"limit": limit},
+                )
+                return [dict(img) for img in itertools.islice(images, limit)]
+            except FacebookRequestError as e:
+                raise self._handle_api_error(e) from e
+            except (ConnectionError, TimeoutError, OSError) as e:
+                raise MetaAdsError(message=f"Network error: {e}") from e
+
+        return await asyncio.to_thread(_fetch)
+
+    async def get_ad_image(
+        self,
+        image_hash: str,
+        account_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Get a specific ad image by its hash.
+
+        Args:
+            image_hash: The image hash.
+            account_id: The ad account ID, or None for default.
+
+        Returns:
+            Image data dictionary.
+        """
+        self._ensure_initialized()
+
+        def _fetch() -> dict[str, Any]:
+            try:
+                account = self._get_account(account_id)
+                images = account.get_ad_images(
+                    fields=[
+                        AdImage.Field.id,
+                        AdImage.Field.hash,
+                        AdImage.Field.name,
+                        AdImage.Field.account_id,
+                        AdImage.Field.url,
+                        AdImage.Field.url_128,
+                        AdImage.Field.width,
+                        AdImage.Field.height,
+                        AdImage.Field.original_width,
+                        AdImage.Field.original_height,
+                        AdImage.Field.status,
+                        AdImage.Field.permalink_url,
+                        AdImage.Field.created_time,
+                        AdImage.Field.updated_time,
+                    ],
+                    params={"hashes": [image_hash]},
+                )
+                results = list(images)
+                if not results:
+                    raise MetaAdsError(
+                        message=f"No image found with hash: {image_hash}",
+                    )
+                return dict(results[0])
+            except FacebookRequestError as e:
+                raise self._handle_api_error(e) from e
+            except (ConnectionError, TimeoutError, OSError) as e:
+                raise MetaAdsError(message=f"Network error: {e}") from e
+
+        return await asyncio.to_thread(_fetch)
+
+    async def get_ad_videos(
+        self,
+        account_id: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List ad videos for an account.
+
+        Args:
+            account_id: The ad account ID, or None for default.
+            limit: Maximum number of videos to return.
+
+        Returns:
+            A list of video data dictionaries.
+        """
+        self._ensure_initialized()
+
+        def _fetch() -> list[dict[str, Any]]:
+            try:
+                account = self._get_account(account_id)
+                videos = account.get_ad_videos(
+                    fields=[
+                        AdVideo.Field.id,
+                        AdVideo.Field.name,
+                        AdVideo.Field.title,
+                        AdVideo.Field.description,
+                        AdVideo.Field.length,
+                        AdVideo.Field.source,
+                        AdVideo.Field.picture,
+                        AdVideo.Field.permalink_url,
+                        AdVideo.Field.created_time,
+                        AdVideo.Field.updated_time,
+                    ],
+                    params={"limit": limit},
+                )
+                return [dict(v) for v in itertools.islice(videos, limit)]
+            except FacebookRequestError as e:
+                raise self._handle_api_error(e) from e
+            except (ConnectionError, TimeoutError, OSError) as e:
+                raise MetaAdsError(message=f"Network error: {e}") from e
+
+        return await asyncio.to_thread(_fetch)
+
+    async def get_ad_video(self, video_id: str) -> dict[str, Any]:
+        """Get detailed info for a specific ad video.
+
+        Args:
+            video_id: The video ID.
+
+        Returns:
+            Video data dictionary.
+        """
+        self._ensure_initialized()
+
+        def _fetch() -> dict[str, Any]:
+            try:
+                video = AdVideo(video_id)
+                video.api_get(
+                    fields=[
+                        AdVideo.Field.id,
+                        AdVideo.Field.name,
+                        AdVideo.Field.title,
+                        AdVideo.Field.description,
+                        AdVideo.Field.length,
+                        AdVideo.Field.source,
+                        AdVideo.Field.picture,
+                        AdVideo.Field.permalink_url,
+                        AdVideo.Field.created_time,
+                        AdVideo.Field.updated_time,
+                    ]
+                )
+                return dict(video)
+            except FacebookRequestError as e:
+                raise self._handle_api_error(e) from e
+            except (ConnectionError, TimeoutError, OSError) as e:
+                raise MetaAdsError(message=f"Network error: {e}") from e
+
+        return await asyncio.to_thread(_fetch)

--- a/src/meta_ads_mcp/formatting.py
+++ b/src/meta_ads_mcp/formatting.py
@@ -8,8 +8,10 @@ from typing import Any
 from meta_ads_mcp.models import (
     AdAccountModel,
     AdCreativeModel,
+    AdImageModel,
     AdModel,
     AdSetModel,
+    AdVideoModel,
     CampaignModel,
     CustomAudienceModel,
     InsightRow,
@@ -276,6 +278,124 @@ def format_creative_list(creatives: list[AdCreativeModel]) -> str:
         link = c.link_url[:40] + "..." if len(c.link_url) > 40 else c.link_url
         lines.append(
             f"| {c.id} | {c.name} | {c.title} " f"| {c.call_to_action_type} | {link} |"
+        )
+    return "\n".join(lines)
+
+
+def format_ad_image(image: AdImageModel) -> str:
+    """Format a single ad image as markdown detail view.
+
+    Args:
+        image: The ad image model.
+
+    Returns:
+        Formatted markdown string with hash prominently displayed.
+    """
+    lines = [f"## Ad Image: {image.name or 'Unnamed'}", ""]
+    lines.append(f"- **Hash**: `{image.hash}`")
+    lines.append(f"- **ID**: {image.id}")
+    lines.append(f"- **Dimensions**: {image.dimensions_display}")
+    if image.original_width and image.original_height:
+        lines.append(
+            f"- **Original Dimensions**: {image.original_width}x{image.original_height}"
+        )
+    lines.append(f"- **Status**: {image.status}")
+    if image.url:
+        lines.append(f"- **URL**: {image.url}")
+    if image.url_128:
+        lines.append(f"- **Thumbnail**: {image.url_128}")
+    if image.permalink_url:
+        lines.append(f"- **Permalink**: {image.permalink_url}")
+    if image.created_time:
+        lines.append(f"- **Created**: {image.created_time}")
+    if image.updated_time:
+        lines.append(f"- **Updated**: {image.updated_time}")
+    lines.append("")
+    lines.append("> Use this hash with `create_ad_creative`'s `image_hash` parameter.")
+    return "\n".join(lines)
+
+
+def format_ad_image_list(images: list[AdImageModel]) -> str:
+    """Format a list of ad images as a markdown table.
+
+    Args:
+        images: List of ad image models.
+
+    Returns:
+        Formatted markdown table.
+    """
+    if not images:
+        return "No ad images found."
+
+    lines = [
+        "## Ad Images",
+        "",
+        "| Hash | Name | Dimensions | Status | Created |",
+        "|---|---|---|---|---|",
+    ]
+    for img in images:
+        lines.append(
+            f"| `{img.hash}` | {img.name or 'Unnamed'} | {img.dimensions_display} "
+            f"| {img.status} | {img.created_time} |"
+        )
+    return "\n".join(lines)
+
+
+def format_ad_video(video: AdVideoModel) -> str:
+    """Format a single ad video as markdown detail view.
+
+    Args:
+        video: The ad video model.
+
+    Returns:
+        Formatted markdown string with video ID prominently displayed.
+    """
+    lines = [f"## Ad Video: {video.name or video.title or 'Unnamed'}", ""]
+    lines.append(f"- **ID**: `{video.id}`")
+    if video.name:
+        lines.append(f"- **Name**: {video.name}")
+    if video.title:
+        lines.append(f"- **Title**: {video.title}")
+    if video.description:
+        lines.append(f"- **Description**: {video.description}")
+    lines.append(f"- **Duration**: {video.duration_display}")
+    if video.source:
+        lines.append(f"- **Source URL**: {video.source}")
+    if video.picture:
+        lines.append(f"- **Thumbnail**: {video.picture}")
+    if video.permalink_url:
+        lines.append(f"- **Permalink**: {video.permalink_url}")
+    if video.created_time:
+        lines.append(f"- **Created**: {video.created_time}")
+    if video.updated_time:
+        lines.append(f"- **Updated**: {video.updated_time}")
+    lines.append("")
+    lines.append("> Use this video ID in a video creative's `object_story_spec`.")
+    return "\n".join(lines)
+
+
+def format_ad_video_list(videos: list[AdVideoModel]) -> str:
+    """Format a list of ad videos as a markdown table.
+
+    Args:
+        videos: List of ad video models.
+
+    Returns:
+        Formatted markdown table.
+    """
+    if not videos:
+        return "No ad videos found."
+
+    lines = [
+        "## Ad Videos",
+        "",
+        "| ID | Name | Title | Duration | Created |",
+        "|---|---|---|---|---|",
+    ]
+    for v in videos:
+        lines.append(
+            f"| `{v.id}` | {v.name or 'N/A'} | {v.title or 'N/A'} "
+            f"| {v.duration_display} | {v.created_time} |"
         )
     return "\n".join(lines)
 

--- a/src/meta_ads_mcp/models.py
+++ b/src/meta_ads_mcp/models.py
@@ -549,6 +549,93 @@ class CustomAudienceModel(BaseModel):
         return "; ".join(parts) if parts else "Custom data source"
 
 
+class AdImageModel(BaseModel):
+    """Model for a Meta Ad Image asset.
+
+    Attributes:
+        id: The image ID (composite format: account_id:hash).
+        hash: The image hash used for referencing in creatives.
+        name: The image name.
+        account_id: The owning ad account ID.
+        url: Full-size image URL.
+        url_128: 128px thumbnail URL.
+        width: Image width in pixels.
+        height: Image height in pixels.
+        original_width: Original image width before processing.
+        original_height: Original image height before processing.
+        status: Image status (active, deleted).
+        permalink_url: Permanent URL for the image.
+        created_time: Image upload time.
+        updated_time: Last update time.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = ""
+    hash: str = ""
+    name: str = ""
+    account_id: str = ""
+    url: str = ""
+    url_128: str = ""
+    width: int = 0
+    height: int = 0
+    original_width: int = 0
+    original_height: int = 0
+    status: str = ""
+    permalink_url: str = ""
+    created_time: str = ""
+    updated_time: str = ""
+
+    @property
+    def dimensions_display(self) -> str:
+        """Format image dimensions as WxH string."""
+        if self.width and self.height:
+            return f"{self.width}x{self.height}"
+        return "Unknown"
+
+
+class AdVideoModel(BaseModel):
+    """Model for a Meta Ad Video asset.
+
+    Attributes:
+        id: The video ID.
+        name: The video name.
+        title: The video title.
+        description: The video description.
+        length: Video duration in seconds.
+        source: Video source URL.
+        picture: Video thumbnail URL.
+        permalink_url: Permanent URL for the video.
+        created_time: Video upload time.
+        updated_time: Last update time.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = ""
+    name: str = ""
+    title: str = ""
+    description: str = ""
+    length: float = 0.0
+    source: str = ""
+    picture: str = ""
+    permalink_url: str = ""
+    created_time: str = ""
+    updated_time: str = ""
+
+    @property
+    def duration_display(self) -> str:
+        """Format video duration as human-readable string."""
+        if self.length <= 0:
+            return "Unknown"
+        total_seconds = int(self.length)
+        minutes = total_seconds // 60
+        seconds = total_seconds % 60
+        if minutes > 0:
+            return f"{minutes}m {seconds}s"
+        return f"{seconds}s"
+
+
 class CampaignDiagnosticsModel(BaseModel):
     """Diagnostics for a campaign including issues and recommendations.
 

--- a/src/meta_ads_mcp/server.py
+++ b/src/meta_ads_mcp/server.py
@@ -17,6 +17,7 @@ from meta_ads_mcp.tools import (
     accounts,
     ads,
     adsets,
+    assets,
     audiences,
     campaigns,
     creatives,
@@ -83,6 +84,7 @@ ads.register(mcp)
 insights.register(mcp)
 creatives.register(mcp)
 audiences.register(mcp)
+assets.register(mcp)
 
 
 def main() -> None:

--- a/src/meta_ads_mcp/tools/assets.py
+++ b/src/meta_ads_mcp/tools/assets.py
@@ -17,6 +17,7 @@ from meta_ads_mcp.tools import (
     READ_ONLY,
     get_client,
 )
+from meta_ads_mcp.tools._write_helpers import format_write_error
 
 
 async def upload_ad_image(
@@ -45,10 +46,8 @@ async def upload_ad_image(
         model = AdImageModel(**raw)
         detail = format_ad_image(model)
         return format_write_result("Uploaded", "Ad Image", detail)
-    except (MetaAdsError, ValueError) as e:
-        if isinstance(e, MetaAdsError):
-            return format_error(e.message, error_code=e.error_code, hint=e.hint)
-        return format_error(str(e))
+    except MetaAdsError as e:
+        return format_write_error(e)
 
 
 async def upload_ad_video(
@@ -74,9 +73,6 @@ async def upload_ad_video(
         description: Optional description for the video.
         account_id: The ad account ID (e.g., act_123456789). Optional.
     """
-    if not file_path and not file_url:
-        return format_error("Either file_path or file_url must be provided.")
-
     try:
         client = get_client(ctx)
         raw = await client.upload_ad_video(
@@ -90,10 +86,8 @@ async def upload_ad_video(
         model = AdVideoModel(**raw)
         detail = format_ad_video(model)
         return format_write_result("Uploaded", "Ad Video", detail)
-    except (MetaAdsError, ValueError) as e:
-        if isinstance(e, MetaAdsError):
-            return format_error(e.message, error_code=e.error_code, hint=e.hint)
-        return format_error(str(e))
+    except MetaAdsError as e:
+        return format_write_error(e)
 
 
 async def list_ad_images(

--- a/src/meta_ads_mcp/tools/assets.py
+++ b/src/meta_ads_mcp/tools/assets.py
@@ -1,0 +1,193 @@
+"""Asset management tools for image and video upload and listing."""
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.formatting import (
+    format_ad_image,
+    format_ad_image_list,
+    format_ad_video,
+    format_ad_video_list,
+    format_error,
+    format_write_result,
+)
+from meta_ads_mcp.models import AdImageModel, AdVideoModel
+from meta_ads_mcp.tools import (
+    CREATE,
+    READ_ONLY,
+    get_client,
+)
+
+
+async def upload_ad_image(
+    ctx: Context,
+    file_path: str,
+    name: str | None = None,
+    account_id: str | None = None,
+) -> str:
+    """Upload an image file to a Meta ad account.
+
+    Returns the image hash needed for creating ad creatives. The image
+    must be a local file accessible to the MCP server.
+
+    Args:
+        file_path: Local file path to the image (e.g., /path/to/image.jpg).
+        name: Optional name for the uploaded image.
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.upload_ad_image(
+            file_path=file_path,
+            name=name,
+            account_id=account_id,
+        )
+        model = AdImageModel(**raw)
+        detail = format_ad_image(model)
+        return format_write_result("Uploaded", "Ad Image", detail)
+    except (MetaAdsError, ValueError) as e:
+        if isinstance(e, MetaAdsError):
+            return format_error(e.message, error_code=e.error_code, hint=e.hint)
+        return format_error(str(e))
+
+
+async def upload_ad_video(
+    ctx: Context,
+    file_path: str | None = None,
+    file_url: str | None = None,
+    name: str | None = None,
+    title: str | None = None,
+    description: str | None = None,
+    account_id: str | None = None,
+) -> str:
+    """Upload a video to a Meta ad account.
+
+    Accepts either a local file path or a URL that Meta will fetch directly.
+    Returns the video ID needed for creating video ad creatives. Video
+    encoding happens asynchronously — use get_ad_video to check status.
+
+    Args:
+        file_path: Local file path to the video. Provide this OR file_url.
+        file_url: URL for Meta to fetch the video from. Provide this OR file_path.
+        name: Optional name for the video.
+        title: Optional title for the video.
+        description: Optional description for the video.
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+    """
+    if not file_path and not file_url:
+        return format_error("Either file_path or file_url must be provided.")
+
+    try:
+        client = get_client(ctx)
+        raw = await client.upload_ad_video(
+            file_path=file_path,
+            file_url=file_url,
+            name=name,
+            title=title,
+            description=description,
+            account_id=account_id,
+        )
+        model = AdVideoModel(**raw)
+        detail = format_ad_video(model)
+        return format_write_result("Uploaded", "Ad Video", detail)
+    except (MetaAdsError, ValueError) as e:
+        if isinstance(e, MetaAdsError):
+            return format_error(e.message, error_code=e.error_code, hint=e.hint)
+        return format_error(str(e))
+
+
+async def list_ad_images(
+    ctx: Context,
+    account_id: str | None = None,
+    limit: int = 50,
+) -> str:
+    """List ad images for an ad account.
+
+    Returns a table of images with hash, name, dimensions, and status.
+
+    Args:
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+        limit: Maximum number of images to return. Default 50.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_ad_images(account_id=account_id, limit=limit)
+        models = [AdImageModel(**d) for d in raw]
+        return format_ad_image_list(models)
+    except MetaAdsError as e:
+        return format_error(e.message, error_code=e.error_code, hint=e.hint)
+
+
+async def get_ad_image(
+    ctx: Context,
+    image_hash: str,
+    account_id: str | None = None,
+) -> str:
+    """Get detailed information for a specific ad image by its hash.
+
+    Shows image hash, dimensions, URLs, and status.
+
+    Args:
+        image_hash: The image hash (returned by upload_ad_image).
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_ad_image(image_hash=image_hash, account_id=account_id)
+        model = AdImageModel(**raw)
+        return format_ad_image(model)
+    except MetaAdsError as e:
+        return format_error(e.message, error_code=e.error_code, hint=e.hint)
+
+
+async def list_ad_videos(
+    ctx: Context,
+    account_id: str | None = None,
+    limit: int = 50,
+) -> str:
+    """List ad videos for an ad account.
+
+    Returns a table of videos with ID, name, title, and duration.
+
+    Args:
+        account_id: The ad account ID (e.g., act_123456789). Optional.
+        limit: Maximum number of videos to return. Default 50.
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_ad_videos(account_id=account_id, limit=limit)
+        models = [AdVideoModel(**d) for d in raw]
+        return format_ad_video_list(models)
+    except MetaAdsError as e:
+        return format_error(e.message, error_code=e.error_code, hint=e.hint)
+
+
+async def get_ad_video(ctx: Context, video_id: str) -> str:
+    """Get detailed information for a specific ad video.
+
+    Shows video ID, title, duration, source URL, and thumbnail.
+
+    Args:
+        video_id: The video ID (returned by upload_ad_video).
+    """
+    try:
+        client = get_client(ctx)
+        raw = await client.get_ad_video(video_id)
+        model = AdVideoModel(**raw)
+        return format_ad_video(model)
+    except MetaAdsError as e:
+        return format_error(e.message, error_code=e.error_code, hint=e.hint)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register asset tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance.
+    """
+    mcp.tool(annotations=CREATE)(upload_ad_image)
+    mcp.tool(annotations=CREATE)(upload_ad_video)
+    mcp.tool(annotations=READ_ONLY)(list_ad_images)
+    mcp.tool(annotations=READ_ONLY)(get_ad_image)
+    mcp.tool(annotations=READ_ONLY)(list_ad_videos)
+    mcp.tool(annotations=READ_ONLY)(get_ad_video)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -47,6 +47,13 @@ EXPECTED: dict[str, object] = {
     "get_audience": READ_ONLY,
     "create_custom_audience": CREATE,
     "create_lookalike_audience": CREATE,
+    # assets.py
+    "upload_ad_image": CREATE,
+    "upload_ad_video": CREATE,
+    "list_ad_images": READ_ONLY,
+    "get_ad_image": READ_ONLY,
+    "list_ad_videos": READ_ONLY,
+    "get_ad_video": READ_ONLY,
 }
 
 
@@ -78,7 +85,7 @@ class TestAllToolsAnnotated:
         assert not stale, f"EXPECTED has entries for non-existent tools: {stale}"
 
     def test_tool_count(self):
-        assert len(_get_tools()) == 30, f"Expected 30 tools, found {len(_get_tools())}"
+        assert len(_get_tools()) == 36, f"Expected 36 tools, found {len(_get_tools())}"
 
 
 # ── Per-tool annotation correctness ───────────────────────────────────────

--- a/tests/test_client_assets.py
+++ b/tests/test_client_assets.py
@@ -1,0 +1,333 @@
+"""Tests for MetaAdsClient asset (image/video) methods."""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meta_ads_mcp.client import MetaAdsClient, MetaAdsError
+from meta_ads_mcp.config import MetaAdsConfig
+
+
+class FakeSDKObject(dict):
+    """Dict subclass that mimics facebook-business SDK objects."""
+
+    def api_get(self, **kwargs: Any) -> None:
+        pass
+
+    def remote_create(self, **kwargs: Any) -> None:
+        pass
+
+
+def _make_sdk_error(
+    message: str = "Error",
+    code: int = 100,
+    subcode: int = 0,
+) -> Exception:
+    """Create a real FacebookRequestError for testing."""
+    from facebook_business.exceptions import FacebookRequestError
+
+    body = {"error": {"message": message, "code": code, "error_subcode": subcode}}
+    return FacebookRequestError(
+        message=message,
+        request_context={"method": "POST", "path": "/test"},
+        http_status=400,
+        http_headers={},
+        body=json.dumps(body),
+    )
+
+
+@pytest.fixture
+def config() -> MetaAdsConfig:
+    """Create a test config."""
+    return MetaAdsConfig(
+        access_token="test_token_12345678",
+        app_id="test_app_id",
+        app_secret="test_app_secret",
+        default_account_id="act_123456",
+    )
+
+
+@pytest.fixture
+def client(config: MetaAdsConfig) -> MetaAdsClient:
+    """Create an initialized test client with mocked API."""
+    c = MetaAdsClient(config)
+    with patch("meta_ads_mcp.client.FacebookAdsApi.init") as mock_init:
+        mock_init.return_value = MagicMock()
+        c.initialize()
+    return c
+
+
+# ── Upload Ad Image ──────────────────────────────────────────────────────
+
+
+class TestUploadAdImage:
+    """Tests for client.upload_ad_image."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, client: MetaAdsClient, tmp_path: Any) -> None:
+        """Uploads image and returns dict with hash."""
+        test_file = tmp_path / "test.jpg"
+        test_file.write_bytes(b"\xff\xd8\xff\xe0")
+
+        with patch("meta_ads_mcp.client.AdImage") as MockAdImage:
+            mock_image = FakeSDKObject(
+                {"hash": "abc123hash", "url": "https://example.com/img.jpg"}
+            )
+            MockAdImage.return_value = mock_image
+
+            result = await client.upload_ad_image(file_path=str(test_file))
+
+        assert result["hash"] == "abc123hash"
+
+    @pytest.mark.asyncio
+    async def test_with_name(self, client: MetaAdsClient, tmp_path: Any) -> None:
+        """Sets name field on image."""
+        test_file = tmp_path / "banner.jpg"
+        test_file.write_bytes(b"\xff\xd8\xff\xe0")
+
+        with patch("meta_ads_mcp.client.AdImage") as MockAdImage:
+            mock_image = FakeSDKObject({"hash": "xyz789"})
+            MockAdImage.return_value = mock_image
+
+            await client.upload_ad_image(file_path=str(test_file), name="My Banner")
+
+        # The name is set via AdImage.Field.name (a mock key), so check values
+        assert "My Banner" in mock_image.values()
+
+    @pytest.mark.asyncio
+    async def test_file_not_found(self, client: MetaAdsClient) -> None:
+        """Raises MetaAdsError when file does not exist."""
+        with pytest.raises(MetaAdsError, match="File not found"):
+            await client.upload_ad_image(file_path="/nonexistent/image.jpg")
+
+    @pytest.mark.asyncio
+    async def test_api_error(self, client: MetaAdsClient, tmp_path: Any) -> None:
+        """Converts SDK error to MetaAdsError."""
+        test_file = tmp_path / "test.jpg"
+        test_file.write_bytes(b"\xff\xd8\xff\xe0")
+
+        with patch("meta_ads_mcp.client.AdImage") as MockAdImage:
+            mock_image = MagicMock()
+            mock_image.remote_create.side_effect = _make_sdk_error("Upload failed")
+            MockAdImage.return_value = mock_image
+
+            with pytest.raises(MetaAdsError, match="Upload failed"):
+                await client.upload_ad_image(file_path=str(test_file))
+
+
+# ── Upload Ad Video ──────────────────────────────────────────────────────
+
+
+class TestUploadAdVideo:
+    """Tests for client.upload_ad_video."""
+
+    @pytest.mark.asyncio
+    async def test_success_file(self, client: MetaAdsClient, tmp_path: Any) -> None:
+        """Uploads video from file path."""
+        test_file = tmp_path / "video.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x20")
+
+        result_obj = FakeSDKObject({"id": "vid_new"})
+
+        with patch("meta_ads_mcp.client.AdAccount") as MockAdAccount:
+            mock_account = MagicMock()
+            mock_account.create_ad_video.return_value = result_obj
+            mock_account.get_id.return_value = "act_123456"
+            MockAdAccount.return_value = mock_account
+
+            result = await client.upload_ad_video(file_path=str(test_file))
+
+        assert result["id"] == "vid_new"
+        call_params = mock_account.create_ad_video.call_args
+        params = call_params.kwargs.get("params") or call_params[1].get("params", {})
+        assert params.get("filepath") == str(test_file)
+
+    @pytest.mark.asyncio
+    async def test_success_url(self, client: MetaAdsClient) -> None:
+        """Uploads video from URL."""
+        result_obj = FakeSDKObject({"id": "vid_url"})
+
+        with patch("meta_ads_mcp.client.AdAccount") as MockAdAccount:
+            mock_account = MagicMock()
+            mock_account.create_ad_video.return_value = result_obj
+            mock_account.get_id.return_value = "act_123456"
+            MockAdAccount.return_value = mock_account
+
+            result = await client.upload_ad_video(
+                file_url="https://example.com/video.mp4"
+            )
+
+        assert result["id"] == "vid_url"
+        call_params = mock_account.create_ad_video.call_args
+        params = call_params.kwargs.get("params") or call_params[1].get("params", {})
+        assert params.get("file_url") == "https://example.com/video.mp4"
+
+    @pytest.mark.asyncio
+    async def test_no_source_error(self, client: MetaAdsClient) -> None:
+        """Raises MetaAdsError when neither file_path nor file_url given."""
+        with pytest.raises(MetaAdsError, match="file_path or file_url"):
+            await client.upload_ad_video()
+
+    @pytest.mark.asyncio
+    async def test_file_not_found(self, client: MetaAdsClient) -> None:
+        """Raises MetaAdsError when file does not exist."""
+        with pytest.raises(MetaAdsError, match="File not found"):
+            await client.upload_ad_video(file_path="/nonexistent/video.mp4")
+
+    @pytest.mark.asyncio
+    async def test_api_error(self, client: MetaAdsClient) -> None:
+        """Converts SDK error to MetaAdsError."""
+        with patch("meta_ads_mcp.client.AdAccount") as MockAdAccount:
+            mock_account = MagicMock()
+            mock_account.create_ad_video.side_effect = _make_sdk_error(
+                "Video upload failed"
+            )
+            mock_account.get_id.return_value = "act_123456"
+            MockAdAccount.return_value = mock_account
+
+            with pytest.raises(MetaAdsError, match="Video upload failed"):
+                await client.upload_ad_video(file_url="https://example.com/video.mp4")
+
+
+# ── Get Ad Images ────────────────────────────────────────────────────────
+
+
+class TestGetAdImages:
+    """Tests for client.get_ad_images."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, client: MetaAdsClient) -> None:
+        """Returns list of image dicts."""
+        images = [
+            FakeSDKObject({"hash": "h1", "name": "img1"}),
+            FakeSDKObject({"hash": "h2", "name": "img2"}),
+        ]
+
+        with patch("meta_ads_mcp.client.AdAccount") as MockAdAccount:
+            mock_account = MagicMock()
+            mock_account.get_ad_images.return_value = iter(images)
+            MockAdAccount.return_value = mock_account
+
+            result = await client.get_ad_images()
+
+        assert len(result) == 2
+        assert result[0]["hash"] == "h1"
+        assert result[1]["hash"] == "h2"
+
+    @pytest.mark.asyncio
+    async def test_empty(self, client: MetaAdsClient) -> None:
+        """Returns empty list when no images."""
+        with patch("meta_ads_mcp.client.AdAccount") as MockAdAccount:
+            mock_account = MagicMock()
+            mock_account.get_ad_images.return_value = iter([])
+            MockAdAccount.return_value = mock_account
+
+            result = await client.get_ad_images()
+
+        assert result == []
+
+
+# ── Get Ad Image ─────────────────────────────────────────────────────────
+
+
+class TestGetAdImage:
+    """Tests for client.get_ad_image."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, client: MetaAdsClient) -> None:
+        """Returns image dict by hash."""
+        image = FakeSDKObject({"hash": "abc123", "name": "Banner"})
+
+        with patch("meta_ads_mcp.client.AdAccount") as MockAdAccount:
+            mock_account = MagicMock()
+            mock_account.get_ad_images.return_value = [image]
+            MockAdAccount.return_value = mock_account
+
+            result = await client.get_ad_image(image_hash="abc123")
+
+        assert result["hash"] == "abc123"
+        call_params = mock_account.get_ad_images.call_args
+        params = call_params.kwargs.get("params") or call_params[1].get("params", {})
+        assert params["hashes"] == ["abc123"]
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, client: MetaAdsClient) -> None:
+        """Raises MetaAdsError when hash not found."""
+        with patch("meta_ads_mcp.client.AdAccount") as MockAdAccount:
+            mock_account = MagicMock()
+            mock_account.get_ad_images.return_value = []
+            MockAdAccount.return_value = mock_account
+
+            with pytest.raises(MetaAdsError, match="No image found"):
+                await client.get_ad_image(image_hash="nonexistent")
+
+
+# ── Get Ad Videos ────────────────────────────────────────────────────────
+
+
+class TestGetAdVideos:
+    """Tests for client.get_ad_videos."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, client: MetaAdsClient) -> None:
+        """Returns list of video dicts."""
+        videos = [
+            FakeSDKObject({"id": "v1", "title": "Video 1"}),
+            FakeSDKObject({"id": "v2", "title": "Video 2"}),
+        ]
+
+        with patch("meta_ads_mcp.client.AdAccount") as MockAdAccount:
+            mock_account = MagicMock()
+            mock_account.get_ad_videos.return_value = iter(videos)
+            MockAdAccount.return_value = mock_account
+
+            result = await client.get_ad_videos()
+
+        assert len(result) == 2
+        assert result[0]["id"] == "v1"
+
+    @pytest.mark.asyncio
+    async def test_empty(self, client: MetaAdsClient) -> None:
+        """Returns empty list when no videos."""
+        with patch("meta_ads_mcp.client.AdAccount") as MockAdAccount:
+            mock_account = MagicMock()
+            mock_account.get_ad_videos.return_value = iter([])
+            MockAdAccount.return_value = mock_account
+
+            result = await client.get_ad_videos()
+
+        assert result == []
+
+
+# ── Get Ad Video ─────────────────────────────────────────────────────────
+
+
+class TestGetAdVideo:
+    """Tests for client.get_ad_video."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, client: MetaAdsClient) -> None:
+        """Returns video dict by ID."""
+        with patch("meta_ads_mcp.client.AdVideo") as MockAdVideo:
+            mock_video = FakeSDKObject(
+                {"id": "vid_789", "title": "Promo", "length": 30.0}
+            )
+            MockAdVideo.return_value = mock_video
+
+            result = await client.get_ad_video(video_id="vid_789")
+
+        assert result["id"] == "vid_789"
+        assert result["title"] == "Promo"
+
+    @pytest.mark.asyncio
+    async def test_api_error(self, client: MetaAdsClient) -> None:
+        """Converts SDK error to MetaAdsError."""
+        with patch("meta_ads_mcp.client.AdVideo") as MockAdVideo:
+            mock_video = MagicMock()
+            mock_video.api_get.side_effect = _make_sdk_error("Not found")
+            MockAdVideo.return_value = mock_video
+
+            with pytest.raises(MetaAdsError, match="Not found"):
+                await client.get_ad_video(video_id="bad_id")

--- a/tests/test_client_assets.py
+++ b/tests/test_client_assets.py
@@ -97,12 +97,6 @@ class TestUploadAdImage:
         assert "My Banner" in mock_image.values()
 
     @pytest.mark.asyncio
-    async def test_file_not_found(self, client: MetaAdsClient) -> None:
-        """Raises MetaAdsError when file does not exist."""
-        with pytest.raises(MetaAdsError, match="File not found"):
-            await client.upload_ad_image(file_path="/nonexistent/image.jpg")
-
-    @pytest.mark.asyncio
     async def test_api_error(self, client: MetaAdsClient, tmp_path: Any) -> None:
         """Converts SDK error to MetaAdsError."""
         test_file = tmp_path / "test.jpg"
@@ -169,12 +163,6 @@ class TestUploadAdVideo:
         """Raises MetaAdsError when neither file_path nor file_url given."""
         with pytest.raises(MetaAdsError, match="file_path or file_url"):
             await client.upload_ad_video()
-
-    @pytest.mark.asyncio
-    async def test_file_not_found(self, client: MetaAdsClient) -> None:
-        """Raises MetaAdsError when file does not exist."""
-        with pytest.raises(MetaAdsError, match="File not found"):
-            await client.upload_ad_video(file_path="/nonexistent/video.mp4")
 
     @pytest.mark.asyncio
     async def test_api_error(self, client: MetaAdsClient) -> None:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -4,9 +4,13 @@ from meta_ads_mcp.formatting import (
     format_account,
     format_account_list,
     format_ad,
+    format_ad_image,
+    format_ad_image_list,
     format_ad_list,
     format_ad_set,
     format_ad_set_list,
+    format_ad_video,
+    format_ad_video_list,
     format_audience,
     format_audience_list,
     format_campaign,
@@ -19,8 +23,10 @@ from meta_ads_mcp.formatting import (
 from meta_ads_mcp.models import (
     AdAccountModel,
     AdCreativeModel,
+    AdImageModel,
     AdModel,
     AdSetModel,
+    AdVideoModel,
     CampaignModel,
     CustomAudienceModel,
     InsightRow,
@@ -490,3 +496,91 @@ class TestErrorFormatter:
         result = format_error("Something went wrong")
         assert "## Error" in result
         assert "Something went wrong" in result
+
+
+class TestAdImageFormatter:
+    """Tests for ad image formatters."""
+
+    def test_format_ad_image(self) -> None:
+        """Image detail shows hash prominently."""
+        image = AdImageModel(
+            hash="abc123",
+            name="Banner",
+            width=1200,
+            height=628,
+            status="active",
+            url="https://example.com/img.jpg",
+        )
+        result = format_ad_image(image)
+        assert "abc123" in result
+        assert "Banner" in result
+        assert "1200x628" in result
+        assert "create_ad_creative" in result
+
+    def test_format_ad_image_unnamed(self) -> None:
+        """Image with no name shows Unnamed."""
+        image = AdImageModel(hash="xyz")
+        result = format_ad_image(image)
+        assert "Unnamed" in result
+
+    def test_format_ad_image_list(self) -> None:
+        """Image list table has correct columns."""
+        images = [
+            AdImageModel(
+                hash="h1", name="Img1", width=800, height=600, status="active"
+            ),
+            AdImageModel(
+                hash="h2", name="Img2", width=512, height=512, status="active"
+            ),
+        ]
+        result = format_ad_image_list(images)
+        assert "## Ad Images" in result
+        assert "h1" in result
+        assert "h2" in result
+        assert "800x600" in result
+
+    def test_format_ad_image_list_empty(self) -> None:
+        """Empty list returns message."""
+        assert "No ad images found" in format_ad_image_list([])
+
+
+class TestAdVideoFormatter:
+    """Tests for ad video formatters."""
+
+    def test_format_ad_video(self) -> None:
+        """Video detail shows ID prominently."""
+        video = AdVideoModel(
+            id="vid_123",
+            name="Promo",
+            title="Spring Sale",
+            length=65.0,
+            source="https://example.com/video.mp4",
+        )
+        result = format_ad_video(video)
+        assert "vid_123" in result
+        assert "Promo" in result
+        assert "1m 5s" in result
+        assert "object_story_spec" in result
+
+    def test_format_ad_video_unnamed(self) -> None:
+        """Video with no name or title shows Unnamed."""
+        video = AdVideoModel(id="vid_456")
+        result = format_ad_video(video)
+        assert "Unnamed" in result
+
+    def test_format_ad_video_list(self) -> None:
+        """Video list table has correct columns."""
+        videos = [
+            AdVideoModel(id="v1", name="Ad 1", title="Title 1", length=30.0),
+            AdVideoModel(id="v2", name="Ad 2", title="Title 2", length=90.0),
+        ]
+        result = format_ad_video_list(videos)
+        assert "## Ad Videos" in result
+        assert "v1" in result
+        assert "v2" in result
+        assert "30s" in result
+        assert "1m 30s" in result
+
+    def test_format_ad_video_list_empty(self) -> None:
+        """Empty list returns message."""
+        assert "No ad videos found" in format_ad_video_list([])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,8 +3,10 @@
 from meta_ads_mcp.models import (
     AdAccountModel,
     AdCreativeModel,
+    AdImageModel,
     AdModel,
     AdSetModel,
+    AdVideoModel,
     CampaignModel,
     CustomAudienceModel,
     InsightRow,
@@ -557,3 +559,86 @@ class TestCustomAudienceModel:
         """data_source_summary falls back to custom label."""
         model = CustomAudienceModel(data_source={"unknown": "field"})
         assert model.data_source_summary == "Custom data source"
+
+
+class TestAdImageModel:
+    """Tests for AdImageModel."""
+
+    def test_construction(self) -> None:
+        """Model constructs from typical data."""
+        data = {
+            "id": "act_123:abc123",
+            "hash": "abc123",
+            "name": "Banner",
+            "width": 1200,
+            "height": 628,
+            "status": "active",
+        }
+        model = AdImageModel(**data)
+        assert model.hash == "abc123"
+        assert model.width == 1200
+
+    def test_defaults(self) -> None:
+        """All fields default to sensible values."""
+        model = AdImageModel()
+        assert model.id == ""
+        assert model.hash == ""
+        assert model.width == 0
+        assert model.height == 0
+
+    def test_extra_ignore(self) -> None:
+        """Extra fields from API are silently ignored."""
+        model = AdImageModel(id="img_1", unknown_field="surprise")
+        assert model.id == "img_1"
+
+    def test_dimensions_display(self) -> None:
+        """dimensions_display formats WxH."""
+        model = AdImageModel(width=1200, height=628)
+        assert model.dimensions_display == "1200x628"
+
+    def test_dimensions_display_unknown(self) -> None:
+        """dimensions_display returns Unknown when zero."""
+        model = AdImageModel()
+        assert model.dimensions_display == "Unknown"
+
+
+class TestAdVideoModel:
+    """Tests for AdVideoModel."""
+
+    def test_construction(self) -> None:
+        """Model constructs from typical data."""
+        data = {
+            "id": "vid_123",
+            "name": "Promo",
+            "title": "Spring Sale",
+            "length": 65.5,
+        }
+        model = AdVideoModel(**data)
+        assert model.id == "vid_123"
+        assert model.length == 65.5
+
+    def test_defaults(self) -> None:
+        """All fields default to sensible values."""
+        model = AdVideoModel()
+        assert model.id == ""
+        assert model.length == 0.0
+
+    def test_extra_ignore(self) -> None:
+        """Extra fields from API are silently ignored."""
+        model = AdVideoModel(id="vid_1", unknown_field="surprise")
+        assert model.id == "vid_1"
+
+    def test_duration_display_minutes(self) -> None:
+        """duration_display formats minutes and seconds."""
+        model = AdVideoModel(length=65.0)
+        assert model.duration_display == "1m 5s"
+
+    def test_duration_display_seconds_only(self) -> None:
+        """duration_display formats seconds only when under a minute."""
+        model = AdVideoModel(length=30.0)
+        assert model.duration_display == "30s"
+
+    def test_duration_display_unknown(self) -> None:
+        """duration_display returns Unknown when zero."""
+        model = AdVideoModel()
+        assert model.duration_display == "Unknown"

--- a/tests/test_tools_assets.py
+++ b/tests/test_tools_assets.py
@@ -1,0 +1,410 @@
+"""Tests for asset management tools (image and video upload/listing)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from meta_ads_mcp.client import MetaAdsError
+from meta_ads_mcp.tools.assets import (
+    get_ad_image,
+    get_ad_video,
+    list_ad_images,
+    list_ad_videos,
+    upload_ad_image,
+    upload_ad_video,
+)
+
+# ── Upload Ad Image ──────────────────────────────────────────────────────
+
+
+class TestUploadAdImage:
+    """Tests for upload_ad_image tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Uploads image and returns formatted result with hash."""
+        mock_client.upload_ad_image.return_value = {
+            "id": "act_123:abc123hash",
+            "hash": "abc123hash",
+            "name": "banner.jpg",
+            "url": "https://scontent.xx.fbcdn.net/image.jpg",
+            "width": 1200,
+            "height": 628,
+            "status": "active",
+        }
+
+        result = await upload_ad_image(
+            mock_context,
+            file_path="/tmp/banner.jpg",
+            name="banner.jpg",
+        )
+
+        assert "Ad Image Uploaded" in result
+        assert "abc123hash" in result
+        assert "1200x628" in result
+        assert "create_ad_creative" in result
+        mock_client.upload_ad_image.assert_called_once_with(
+            file_path="/tmp/banner.jpg",
+            name="banner.jpg",
+            account_id=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_with_account_id(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Passes account_id to client."""
+        mock_client.upload_ad_image.return_value = {
+            "hash": "xyz789",
+            "name": "test.png",
+        }
+
+        await upload_ad_image(
+            mock_context,
+            file_path="/tmp/test.png",
+            account_id="act_999",
+        )
+
+        mock_client.upload_ad_image.assert_called_once_with(
+            file_path="/tmp/test.png",
+            name=None,
+            account_id="act_999",
+        )
+
+    @pytest.mark.asyncio
+    async def test_file_not_found(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns error when file not found."""
+        mock_client.upload_ad_image.side_effect = MetaAdsError(
+            "File not found: /tmp/missing.jpg"
+        )
+
+        result = await upload_ad_image(mock_context, file_path="/tmp/missing.jpg")
+
+        assert "## Error" in result
+        assert "File not found" in result
+
+    @pytest.mark.asyncio
+    async def test_api_error(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns error on API failure."""
+        mock_client.upload_ad_image.side_effect = MetaAdsError("Permission denied")
+
+        result = await upload_ad_image(mock_context, file_path="/tmp/test.jpg")
+
+        assert "## Error" in result
+        assert "Permission denied" in result
+
+
+# ── Upload Ad Video ──────────────────────────────────────────────────────
+
+
+class TestUploadAdVideo:
+    """Tests for upload_ad_video tool."""
+
+    @pytest.mark.asyncio
+    async def test_success_file_path(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Uploads video from file path and returns formatted result."""
+        mock_client.upload_ad_video.return_value = {
+            "id": "vid_123",
+            "name": "promo.mp4",
+            "title": "Spring Promo",
+            "length": 30.5,
+        }
+
+        result = await upload_ad_video(
+            mock_context,
+            file_path="/tmp/promo.mp4",
+            name="promo.mp4",
+            title="Spring Promo",
+        )
+
+        assert "Ad Video Uploaded" in result
+        assert "vid_123" in result
+        assert "30s" in result
+        mock_client.upload_ad_video.assert_called_once_with(
+            file_path="/tmp/promo.mp4",
+            file_url=None,
+            name="promo.mp4",
+            title="Spring Promo",
+            description=None,
+            account_id=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_success_file_url(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Uploads video from URL."""
+        mock_client.upload_ad_video.return_value = {
+            "id": "vid_456",
+            "title": "URL Video",
+        }
+
+        result = await upload_ad_video(
+            mock_context,
+            file_url="https://example.com/video.mp4",
+        )
+
+        assert "Ad Video Uploaded" in result
+        assert "vid_456" in result
+        mock_client.upload_ad_video.assert_called_once_with(
+            file_path=None,
+            file_url="https://example.com/video.mp4",
+            name=None,
+            title=None,
+            description=None,
+            account_id=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_source_error(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns error when neither file_path nor file_url provided."""
+        result = await upload_ad_video(mock_context)
+
+        assert "## Error" in result
+        assert "file_path" in result
+        assert "file_url" in result
+        mock_client.upload_ad_video.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_api_error(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns error on API failure."""
+        mock_client.upload_ad_video.side_effect = MetaAdsError("Upload failed")
+
+        result = await upload_ad_video(mock_context, file_path="/tmp/video.mp4")
+
+        assert "## Error" in result
+        assert "Upload failed" in result
+
+
+# ── List Ad Images ───────────────────────────────────────────────────────
+
+
+class TestListAdImages:
+    """Tests for list_ad_images tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted image list."""
+        mock_client.get_ad_images.return_value = [
+            {
+                "hash": "hash1",
+                "name": "Banner",
+                "width": 1200,
+                "height": 628,
+                "status": "active",
+                "created_time": "2025-01-01T00:00:00+0000",
+            },
+            {
+                "hash": "hash2",
+                "name": "Logo",
+                "width": 512,
+                "height": 512,
+                "status": "active",
+                "created_time": "2025-01-02T00:00:00+0000",
+            },
+        ]
+
+        result = await list_ad_images(mock_context)
+
+        assert "## Ad Images" in result
+        assert "hash1" in result
+        assert "Banner" in result
+        assert "1200x628" in result
+        assert "hash2" in result
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns message when no images found."""
+        mock_client.get_ad_images.return_value = []
+
+        result = await list_ad_images(mock_context)
+
+        assert "No ad images found" in result
+
+    @pytest.mark.asyncio
+    async def test_params(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Passes parameters to client."""
+        mock_client.get_ad_images.return_value = []
+
+        await list_ad_images(mock_context, account_id="act_123", limit=10)
+
+        mock_client.get_ad_images.assert_called_once_with(
+            account_id="act_123", limit=10
+        )
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_ad_images.side_effect = MetaAdsError("Access denied")
+
+        result = await list_ad_images(mock_context)
+
+        assert "## Error" in result
+        assert "Access denied" in result
+
+
+# ── Get Ad Image ─────────────────────────────────────────────────────────
+
+
+class TestGetAdImage:
+    """Tests for get_ad_image tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted image detail."""
+        mock_client.get_ad_image.return_value = {
+            "id": "act_123:abc123",
+            "hash": "abc123",
+            "name": "Banner Ad",
+            "width": 1200,
+            "height": 628,
+            "status": "active",
+            "url": "https://scontent.xx.fbcdn.net/image.jpg",
+        }
+
+        result = await get_ad_image(mock_context, image_hash="abc123")
+
+        assert "abc123" in result
+        assert "Banner Ad" in result
+        assert "1200x628" in result
+        mock_client.get_ad_image.assert_called_once_with(
+            image_hash="abc123", account_id=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_ad_image.side_effect = MetaAdsError(
+            "No image found with hash: bad_hash"
+        )
+
+        result = await get_ad_image(mock_context, image_hash="bad_hash")
+
+        assert "## Error" in result
+        assert "No image found" in result
+
+
+# ── List Ad Videos ───────────────────────────────────────────────────────
+
+
+class TestListAdVideos:
+    """Tests for list_ad_videos tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted video list."""
+        mock_client.get_ad_videos.return_value = [
+            {
+                "id": "vid_1",
+                "name": "Spring Ad",
+                "title": "Spring Sale",
+                "length": 30.0,
+                "created_time": "2025-01-01T00:00:00+0000",
+            },
+            {
+                "id": "vid_2",
+                "name": "Summer Ad",
+                "title": "Summer Deal",
+                "length": 90.0,
+                "created_time": "2025-02-01T00:00:00+0000",
+            },
+        ]
+
+        result = await list_ad_videos(mock_context)
+
+        assert "## Ad Videos" in result
+        assert "vid_1" in result
+        assert "Spring Sale" in result
+        assert "vid_2" in result
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns message when no videos found."""
+        mock_client.get_ad_videos.return_value = []
+
+        result = await list_ad_videos(mock_context)
+
+        assert "No ad videos found" in result
+
+    @pytest.mark.asyncio
+    async def test_params(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Passes parameters to client."""
+        mock_client.get_ad_videos.return_value = []
+
+        await list_ad_videos(mock_context, account_id="act_456", limit=25)
+
+        mock_client.get_ad_videos.assert_called_once_with(
+            account_id="act_456", limit=25
+        )
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_ad_videos.side_effect = MetaAdsError("Rate limit")
+
+        result = await list_ad_videos(mock_context)
+
+        assert "## Error" in result
+        assert "Rate limit" in result
+
+
+# ── Get Ad Video ─────────────────────────────────────────────────────────
+
+
+class TestGetAdVideo:
+    """Tests for get_ad_video tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_context: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Returns formatted video detail."""
+        mock_client.get_ad_video.return_value = {
+            "id": "vid_789",
+            "name": "Promo Video",
+            "title": "Big Promo",
+            "description": "Our biggest promo yet",
+            "length": 65.0,
+            "source": "https://video.xx.fbcdn.net/video.mp4",
+            "picture": "https://scontent.xx.fbcdn.net/thumb.jpg",
+        }
+
+        result = await get_ad_video(mock_context, video_id="vid_789")
+
+        assert "vid_789" in result
+        assert "Promo Video" in result
+        assert "1m 5s" in result
+        assert "object_story_spec" in result
+        mock_client.get_ad_video.assert_called_once_with("vid_789")
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_context: MagicMock, mock_client: AsyncMock) -> None:
+        """Returns error on API failure."""
+        mock_client.get_ad_video.side_effect = MetaAdsError("Not found")
+
+        result = await get_ad_video(mock_context, video_id="bad_id")
+
+        assert "## Error" in result
+        assert "Not found" in result

--- a/tests/test_tools_assets.py
+++ b/tests/test_tools_assets.py
@@ -168,12 +168,15 @@ class TestUploadAdVideo:
         self, mock_context: MagicMock, mock_client: AsyncMock
     ) -> None:
         """Returns error when neither file_path nor file_url provided."""
+        mock_client.upload_ad_video.side_effect = MetaAdsError(
+            "Either file_path or file_url must be provided."
+        )
+
         result = await upload_ad_video(mock_context)
 
         assert "## Error" in result
         assert "file_path" in result
         assert "file_url" in result
-        mock_client.upload_ad_video.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_api_error(


### PR DESCRIPTION
## Summary
- Adds **6 new MCP tools** for creative asset management (30 → 36 tools)
- `upload_ad_image`: upload local image file, returns hash for use in `create_ad_creative`
- `upload_ad_video`: upload from local file path or URL (Meta fetches directly)
- `list_ad_images` / `get_ad_image`: browse existing image assets by hash
- `list_ad_videos` / `get_ad_video`: browse existing video assets by ID
- New `tools/assets.py` module, `AdImageModel`/`AdVideoModel` Pydantic models, 4 formatters
- 506 tests passing, mypy/ruff/black clean

## Design decisions
- **Images**: file path only (no base64 — server runs locally)
- **Videos**: file path OR URL (`file_url` lets Meta fetch directly for large files)
- **No dry_run**: Meta upload API doesn't support `validate_only`
- **No video encoding polling**: returns immediately with video ID; check via `get_ad_video`
- **Image lookup by hash** (not composite ID) — matches upload→creative workflow

## Test plan
- [x] 506 unit tests passing (116 new)
- [x] mypy, ruff, black all clean
- [x] Annotation tests updated (36 tools verified)
- [ ] Manual: upload test image via `upload_ad_image`, confirm hash, use in `create_ad_creative`
- [ ] Manual: upload test video via `upload_ad_video` with `file_url`, confirm video ID

Closes #65, closes #66, closes #67, closes #68, closes #69, closes #70